### PR TITLE
Specify PATH for `fdev new web-app` command.

### DIFF
--- a/hugo-site/content/resources/manual/tutorial.md
+++ b/hugo-site/content/resources/manual/tutorial.md
@@ -91,7 +91,7 @@ contract**.
 mkdir -p my-app/web
 mkdir -p my-app/backend
 cd my-app/web
-fdev new web-app
+fdev new web-app .
 ```
 
 This makes a skeleton for:


### PR DESCRIPTION
Copying and pasting this command from the manual doesn't work, since it doesn't specify a path.