### PR TITLE
docs(ghostkey): warn users to back up keys before importing

### DIFF
--- a/hugo-site/content/ghostkey/_index.md
+++ b/hugo-site/content/ghostkey/_index.md
@@ -13,6 +13,12 @@ hold a scarce, donation-backed identity, without ever learning who you are.
 You can also read the [introductory article](/about/news/introducing-ghost-keys/) or
 [watch the interview](/about/news/ghost-keys-ian-interview/).
 
+> **⚠️ Back up your Ghost Key immediately after creating it.** The Ghostkey Vault
+> delegate is still early software and storage is not yet reliable: keys can and do
+> disappear from the vault. When you receive your certificate and signing key, save
+> both to a password manager or other secure backup **before** importing to Freenet.
+> Without a backup, a lost key cannot be recovered and the donation behind it is gone.
+
 ## Why Ghost Keys exist
 
 There is no negative trust on the Internet. Identities are free to create, so a bad
@@ -155,10 +161,14 @@ Ghost Keys are a primitive, not a product. A few of the things they unlock:
 
 ## Storage, backup, and the CLI
 
-If you're running a Freenet node, click **Import to Freenet** on the success page after
-donating; this installs your Ghost Key into the Ghostkey Vault on your node. We also
-recommend downloading the certificate and signing key as a backup, so you can move your
-identity to a new node later.
+**Back up first, import second.** On the success page after donating, save both the
+certificate and the signing key to a password manager (or another secure location)
+**before** you click **Import to Freenet**. The Ghostkey Vault delegate is still
+early software: keys have been observed disappearing from the vault after import, and
+without a saved backup the key (and the donation behind it) cannot be recovered. Treat
+the vault as a convenience, not as the authoritative store of your key, until this is
+fixed. Progress is tracked in
+[freenet/ghostkeys#3](https://github.com/freenet/ghostkeys/issues/3).
 
 For developers, everything is open source:
 

--- a/hugo-site/content/ghostkey/create/_index.md
+++ b/hugo-site/content/ghostkey/create/_index.md
@@ -10,8 +10,14 @@ The key is generated in your browser, then "blinded" before being sent to our se
 signs the blinded key without ever seeing the unblinded version, ensuring that your donation remains
 anonymous. Your browser then unblinds the signature, creating a signed certificate.
 
-It's important to store this certificate securely, such as in a secure note within your password
-manager. You can read an article about Ghost Keys [here](/about/news/introducing-ghost-keys/).
+> **⚠️ Back up your Ghost Key before importing it to Freenet.** Save both the
+> certificate and the signing key to a password manager **before** clicking
+> **Import to Freenet** on the success page. The Ghostkey Vault delegate is still
+> early software and keys have been observed disappearing from the vault; without a
+> backup, a lost key and the donation behind it cannot be recovered. Tracked in
+> [freenet/ghostkeys#3](https://github.com/freenet/ghostkeys/issues/3).
+
+You can read an article about Ghost Keys [here](/about/news/introducing-ghost-keys/).
 
 We offer a $1 donation option to ensure that Ghost Keys are accessible to everyone, especially those
 with limited means. Your generosity directly supports the ongoing development of Freenet, helping us

--- a/hugo-site/content/ghostkey/success/_index.md
+++ b/hugo-site/content/ghostkey/success/_index.md
@@ -14,12 +14,21 @@ without revealing your identity. Please wait a moment while we process your info
 
 ## What's Next?
 
-**Import to Freenet:** If you have a Freenet peer running on this computer, click "Import to
-Freenet" to add your Ghost Key to your local identity vault. Your Freenet peer must be running
-before you click this button.
+> **⚠️ Back up first, import second.** The Ghostkey Vault delegate is still early
+> software and keys have been observed disappearing from the vault after import.
+> **Save your Ghost Key before clicking Import to Freenet** — if it's lost from the
+> vault and you have no backup, the key and the donation behind it cannot be recovered.
+> Tracked in [freenet/ghostkeys#3](https://github.com/freenet/ghostkeys/issues/3).
 
-**Backup:** We strongly recommend downloading your Ghost Key and storing it somewhere safe, such as
-a secure note in a password manager. If you lose access to your Freenet peer, you can re-import
-from the backup.
+**1. Backup (do this first):** Download your Ghost Key and save both the certificate
+and the signing key somewhere safe, such as a secure note in a password manager. This
+is currently the authoritative copy of your key — treat the vault as a convenience, not
+as storage you can rely on.
+
+**2. Import to Freenet:** Once you've backed up, if you have a Freenet peer running on
+this computer, click "Import to Freenet" to add your Ghost Key to your local identity
+vault. Your Freenet peer must be running before you click this button. If you lose
+access to your Freenet peer (or the vault loses the key), you can re-import from the
+backup.
 
 {{< bulma-button href="/ghostkey/" color="#339966" >}}Ghost Key FAQ{{< /bulma-button >}}

--- a/hugo-site/content/ghostkey/success/_index.md
+++ b/hugo-site/content/ghostkey/success/_index.md
@@ -16,13 +16,13 @@ without revealing your identity. Please wait a moment while we process your info
 
 > **⚠️ Back up first, import second.** The Ghostkey Vault delegate is still early
 > software and keys have been observed disappearing from the vault after import.
-> **Save your Ghost Key before clicking Import to Freenet** — if it's lost from the
+> **Save your Ghost Key before clicking Import to Freenet.** If it's lost from the
 > vault and you have no backup, the key and the donation behind it cannot be recovered.
 > Tracked in [freenet/ghostkeys#3](https://github.com/freenet/ghostkeys/issues/3).
 
 **1. Backup (do this first):** Download your Ghost Key and save both the certificate
 and the signing key somewhere safe, such as a secure note in a password manager. This
-is currently the authoritative copy of your key — treat the vault as a convenience, not
+is currently the authoritative copy of your key. Treat the vault as a convenience, not
 as storage you can rely on.
 
 **2. Import to Freenet:** Once you've backed up, if you have a Freenet peer running on


### PR DESCRIPTION
## Problem

The Ghostkey Vault delegate is still early software and users have reported keys disappearing from the vault after import (freenet/ghostkeys#3). Without a backup the donation behind the key is lost.

## Approach

Add prominent warnings to all three ghostkey pages:
- `/ghostkey/` (FAQ): warning banner near the top plus strengthened storage section
- `/ghostkey/create/`: warning above the donation form
- `/ghostkey/success/`: reordered "What's Next?" to put backup first, import second, with an explicit warning callout

Each warning links to freenet/ghostkeys#3 so users can track progress.

## Testing

Content-only changes; verified markdown renders correctly by inspection. No code changes.

Refs freenet/ghostkeys#3.

[AI-assisted - Claude]