### PR TITLE
docs(ghostkey): move backup warning to success page only

### DIFF
--- a/hugo-site/content/ghostkey/_index.md
+++ b/hugo-site/content/ghostkey/_index.md
@@ -13,12 +13,6 @@ hold a scarce, donation-backed identity, without ever learning who you are.
 You can also read the [introductory article](/about/news/introducing-ghost-keys/) or
 [watch the interview](/about/news/ghost-keys-ian-interview/).
 
-> **⚠️ Back up your Ghost Key immediately after creating it.** The Ghostkey Vault
-> delegate is still early software and storage is not yet reliable: keys can and do
-> disappear from the vault. When you receive your certificate and signing key, save
-> both to a password manager or other secure backup **before** importing to Freenet.
-> Without a backup, a lost key cannot be recovered and the donation behind it is gone.
-
 ## Why Ghost Keys exist
 
 There is no negative trust on the Internet. Identities are free to create, so a bad
@@ -161,14 +155,10 @@ Ghost Keys are a primitive, not a product. A few of the things they unlock:
 
 ## Storage, backup, and the CLI
 
-**Back up first, import second.** On the success page after donating, save both the
-certificate and the signing key to a password manager (or another secure location)
-**before** you click **Import to Freenet**. The Ghostkey Vault delegate is still
-early software: keys have been observed disappearing from the vault after import, and
-without a saved backup the key (and the donation behind it) cannot be recovered. Treat
-the vault as a convenience, not as the authoritative store of your key, until this is
-fixed. Progress is tracked in
-[freenet/ghostkeys#3](https://github.com/freenet/ghostkeys/issues/3).
+If you're running a Freenet node, click **Import to Freenet** on the success page after
+donating; this installs your Ghost Key into the Ghostkey Vault on your node. We also
+recommend downloading the certificate and signing key as a backup, so you can move your
+identity to a new node later.
 
 For developers, everything is open source:
 

--- a/hugo-site/content/ghostkey/create/_index.md
+++ b/hugo-site/content/ghostkey/create/_index.md
@@ -10,14 +10,8 @@ The key is generated in your browser, then "blinded" before being sent to our se
 signs the blinded key without ever seeing the unblinded version, ensuring that your donation remains
 anonymous. Your browser then unblinds the signature, creating a signed certificate.
 
-> **⚠️ Back up your Ghost Key before importing it to Freenet.** Save both the
-> certificate and the signing key to a password manager **before** clicking
-> **Import to Freenet** on the success page. The Ghostkey Vault delegate is still
-> early software and keys have been observed disappearing from the vault; without a
-> backup, a lost key and the donation behind it cannot be recovered. Tracked in
-> [freenet/ghostkeys#3](https://github.com/freenet/ghostkeys/issues/3).
-
-You can read an article about Ghost Keys [here](/about/news/introducing-ghost-keys/).
+It's important to store this certificate securely, such as in a secure note within your password
+manager. You can read an article about Ghost Keys [here](/about/news/introducing-ghost-keys/).
 
 We offer a $1 donation option to ensure that Ghost Keys are accessible to everyone, especially those
 with limited means. Your generosity directly supports the ongoing development of Freenet, helping us


### PR DESCRIPTION
## Problem

PR #29 added a backup warning to three places: /ghostkey/ (FAQ), /ghostkey/create/ (donate), and /ghostkey/success/ (post-donation). Feedback from @sanity: the warning only matters at the moment the user is actually shown their freshly created key. Putting it on the FAQ and donate pages is noise that dilutes the message when it actually matters.

## Approach

Remove the warning from the FAQ and create pages and restore their original prose. The stronger success-page warning is unchanged.

## Testing

Content-only; rendered markdown verified by inspection.

[AI-assisted - Claude]