### PR TITLE
docs: add uninstall guidance to quickstart and FAQ

### DIFF
--- a/hugo-site/content/about/faq/index.md
+++ b/hugo-site/content/about/faq/index.md
@@ -20,6 +20,7 @@ aliases:
 - [What is the status of Freenet?](#what-is-the-status-of-freenet)
 - [Can I follow Freenet on social media?](#can-i-follow-freenet-on-social-media)
 - [How can I financially support Freenet development?](#how-can-i-financially-support-freenet-development)
+- [How do I uninstall Freenet?](#how-do-i-uninstall-freenet)
 - [Why does the Freenet project use and mention AI tools?](#why-does-the-freenet-project-use-and-mention-ai-tools)
 
 Freenet is a fully decentralized, peer-to-peer network and a drop-in replacement for the world wide
@@ -215,6 +216,32 @@ You can [donate via credit card or cryptocurrency](/donate), or donate through o
 If you are in a position to make a larger contribution or grant please
 {{< email-protect "gro.teneerf@nai" "email Ian" >}} or reach out to him on
 [𝕏](https://x.com/sanity).
+
+# How do I uninstall Freenet? {#how-do-i-uninstall-freenet}
+
+Run:
+
+```bash
+freenet uninstall
+```
+
+This stops the service, removes the `freenet` and `fdev` binaries, and (with confirmation) deletes your data, config, cache, and logs. Pass `--purge` to skip the confirmation, or `--keep-data` to preserve your data.
+
+**Do not run `sudo freenet uninstall`** if you installed with the `curl | sh` one-liner. The installer puts the binary in `~/.local/bin`, which is not on `sudo`'s PATH, so the command either fails silently or operates on the wrong user's files. Only use `sudo` if you originally installed with `--system`.
+
+If the `freenet` binary isn't on your PATH, invoke it by full path: `~/.local/bin/freenet uninstall`.
+
+If you installed with `cargo install freenet`, the binary is in `~/.cargo/bin/freenet`; run `cargo uninstall freenet` and then clean up the data directories below.
+
+As a manual fallback (e.g. if the binary is missing or broken), delete these paths on Linux:
+
+- `~/.local/bin/freenet`, `~/.local/bin/fdev`
+- `~/.config/systemd/user/freenet.service` (after `systemctl --user disable --now freenet.service`)
+- `~/.local/share/Freenet`, `~/.config/Freenet`, `~/.cache/Freenet`, `~/.cache/freenet`, `~/.local/state/freenet`
+
+On macOS the data, config, cache, and log directories are under `~/Library/Application Support/Freenet`, `~/Library/Caches/Freenet`, and `~/Library/Logs/Freenet`.
+
+Full uninstall instructions, including the manual fallback, are also in the [Quick Start guide](/quickstart/#uninstalling).
 
 # Why does the Freenet project use and mention AI tools? {#why-does-the-freenet-project-use-and-mention-ai-tools}
 

--- a/hugo-site/content/about/faq/index.md
+++ b/hugo-site/content/about/faq/index.md
@@ -241,7 +241,9 @@ As a manual fallback (e.g. if the binary is missing or broken), delete these pat
 
 On macOS the data, config, cache, and log directories are under `~/Library/Application Support/Freenet`, `~/Library/Caches/Freenet`, and `~/Library/Logs/Freenet`.
 
-Full uninstall instructions, including the manual fallback, are also in the [Quick Start guide](/quickstart/#uninstalling).
+On Windows, `freenet uninstall` has a known gap and may leave the config folder behind. After running it, manually remove `%LOCALAPPDATA%\Freenet\bin`, `%LOCALAPPDATA%\The Freenet Project Inc\Freenet`, and `%APPDATA%\The Freenet Project Inc\Freenet`. The [Quick Start guide](/quickstart/#uninstalling) has the full PowerShell snippet.
+
+Full uninstall instructions, including the manual fallback, are in the [Quick Start guide](/quickstart/#uninstalling).
 
 # Why does the Freenet project use and mention AI tools? {#why-does-the-freenet-project-use-and-mention-ai-tools}
 

--- a/hugo-site/content/about/faq/index.md
+++ b/hugo-site/content/about/faq/index.md
@@ -225,25 +225,17 @@ Run:
 freenet uninstall
 ```
 
-This stops the service, removes the `freenet` and `fdev` binaries, and (with confirmation) deletes your data, config, cache, and logs. Pass `--purge` to skip the confirmation, or `--keep-data` to preserve your data.
+This stops the service, removes the `freenet` and `fdev` binaries, and (with confirmation) deletes your data, config, cache, and logs. Pass `--purge` to skip the confirmation, or `--keep-data` to preserve all of them.
 
-**Do not run `sudo freenet uninstall`** if you installed with the `curl | sh` one-liner. The installer puts the binary in `~/.local/bin`, which is not on `sudo`'s PATH, so the command either fails silently or operates on the wrong user's files. Only use `sudo` if you originally installed with `--system`.
+**Do not run `sudo freenet uninstall`** if you installed with the `curl | sh` one-liner. The installer puts the binary in `~/.local/bin`, which is not on `sudo`'s default PATH, so the command fails with `command not found` and your install is left untouched. Only use `sudo` if you originally installed with `--system`.
 
 If the `freenet` binary isn't on your PATH, invoke it by full path: `~/.local/bin/freenet uninstall`.
 
 If you installed with `cargo install freenet`, the binary is in `~/.cargo/bin/freenet`; run `cargo uninstall freenet` and then clean up the data directories below.
 
-As a manual fallback (e.g. if the binary is missing or broken), delete these paths on Linux:
+On Windows, `freenet uninstall` has a known gap and may leave the config folder behind — after running it, also manually remove `%LOCALAPPDATA%\Freenet\bin`, `%LOCALAPPDATA%\The Freenet Project Inc\Freenet`, and `%APPDATA%\The Freenet Project Inc\Freenet`.
 
-- `~/.local/bin/freenet`, `~/.local/bin/fdev`
-- `~/.config/systemd/user/freenet.service` (after `systemctl --user disable --now freenet.service`)
-- `~/.local/share/Freenet`, `~/.config/Freenet`, `~/.cache/Freenet`, `~/.cache/freenet`, `~/.local/state/freenet`
-
-On macOS the data, config, cache, and log directories are under `~/Library/Application Support/Freenet`, `~/Library/Caches/Freenet`, and `~/Library/Logs/Freenet`.
-
-On Windows, `freenet uninstall` has a known gap and may leave the config folder behind. After running it, manually remove `%LOCALAPPDATA%\Freenet\bin`, `%LOCALAPPDATA%\The Freenet Project Inc\Freenet`, and `%APPDATA%\The Freenet Project Inc\Freenet`. The [Quick Start guide](/quickstart/#uninstalling) has the full PowerShell snippet.
-
-Full uninstall instructions, including the manual fallback, are in the [Quick Start guide](/quickstart/#uninstalling).
+The [Quick Start guide](/quickstart/#uninstalling) has the full per-platform manual-fallback snippets (Linux systemd, macOS launchd, Windows PowerShell) for when the binary is missing or broken.
 
 # Why does the Freenet project use and mention AI tools? {#why-does-the-freenet-project-use-and-mention-ai-tools}
 

--- a/hugo-site/content/quickstart/_index.md
+++ b/hugo-site/content/quickstart/_index.md
@@ -53,6 +53,41 @@ riverctl room list                          # list your rooms
 
 Run `riverctl --help` for the full list of commands.
 
+## Uninstalling
+
+To remove Freenet completely:
+
+```bash
+freenet uninstall
+```
+
+This stops the service, removes the binaries, and (with confirmation) deletes your data, config, and logs. Pass `--purge` to skip the confirmation, or `--keep-data` to preserve your data.
+
+**Do not run `sudo freenet uninstall`** for a normal `curl | sh` install. The installer puts the binary in `~/.local/bin`, which is not on `sudo`'s PATH, so the command either fails silently or operates on the wrong user's files. Only use `sudo` if you originally installed with `--system`.
+
+If `freenet` isn't on your PATH, call it by full path: `~/.local/bin/freenet uninstall`.
+
+**Installed with `cargo install freenet`?** The binary lives in `~/.cargo/bin/freenet`. Run `cargo uninstall freenet` (and `cargo uninstall fdev` if you also installed that), then remove the data directories listed below.
+
+### Manual fallback
+
+If the binary is missing or broken, remove everything by hand:
+
+```bash
+# Stop and remove the user service (if installed)
+systemctl --user disable --now freenet.service 2>/dev/null
+rm -f ~/.config/systemd/user/freenet.service
+
+# Remove binaries
+rm -f ~/.local/bin/freenet ~/.local/bin/fdev
+
+# Remove data, config, cache, and logs
+rm -rf ~/.local/share/Freenet ~/.config/Freenet ~/.cache/Freenet \
+       ~/.cache/freenet ~/.local/state/freenet
+```
+
+On macOS, the data, config, cache, and log directories live under `~/Library/Application Support/Freenet`, `~/Library/Caches/Freenet`, and `~/Library/Logs/Freenet` instead.
+
 ## Troubleshooting
 
 If you run into problems, join our [Matrix chat](https://matrix.to/#/#freenet-locutus:matrix.org) for help.

--- a/hugo-site/content/quickstart/_index.md
+++ b/hugo-site/content/quickstart/_index.md
@@ -88,6 +88,21 @@ rm -rf ~/.local/share/Freenet ~/.config/Freenet ~/.cache/Freenet \
 
 On macOS, the data, config, cache, and log directories live under `~/Library/Application Support/Freenet`, `~/Library/Caches/Freenet`, and `~/Library/Logs/Freenet` instead.
 
+**Windows.** On Windows the PowerShell installer (`irm https://freenet.org/install.ps1 | iex`) lays things out a bit differently, and the bundled `freenet uninstall` has a known gap: it removes the data directory but may leave the config folder behind. After running the uninstall, delete these folders manually (PowerShell):
+
+```powershell
+# Binaries
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\Freenet\bin" -ErrorAction SilentlyContinue
+
+# Data (Local AppData)
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\The Freenet Project Inc\Freenet" -ErrorAction SilentlyContinue
+
+# Config and logs (Roaming AppData)
+Remove-Item -Recurse -Force "$env:APPDATA\The Freenet Project Inc\Freenet" -ErrorAction SilentlyContinue
+```
+
+Also check `HKCU:\Software\Microsoft\Windows\CurrentVersion\Run` in the registry for any leftover `Freenet` startup entry and remove it.
+
 ## Troubleshooting
 
 If you run into problems, join our [Matrix chat](https://matrix.to/#/#freenet-locutus:matrix.org) for help.

--- a/hugo-site/content/quickstart/_index.md
+++ b/hugo-site/content/quickstart/_index.md
@@ -61,9 +61,9 @@ To remove Freenet completely:
 freenet uninstall
 ```
 
-This stops the service, removes the binaries, and (with confirmation) deletes your data, config, and logs. Pass `--purge` to skip the confirmation, or `--keep-data` to preserve your data.
+This stops the service, removes the binaries, and (with confirmation) deletes your data, config, cache, and logs. Pass `--purge` to skip the confirmation, or `--keep-data` to preserve all of them.
 
-**Do not run `sudo freenet uninstall`** for a normal `curl | sh` install. The installer puts the binary in `~/.local/bin`, which is not on `sudo`'s PATH, so the command either fails silently or operates on the wrong user's files. Only use `sudo` if you originally installed with `--system`.
+**Do not run `sudo freenet uninstall`** for a normal `curl | sh` install. The installer puts the binary in `~/.local/bin`, which is not on `sudo`'s default PATH, so `sudo freenet uninstall` fails with `command not found` and your install is left untouched. Only use `sudo` if you originally installed with `--system` (in which case the unit file is at `/etc/systemd/system/freenet.service`).
 
 If `freenet` isn't on your PATH, call it by full path: `~/.local/bin/freenet uninstall`.
 
@@ -86,18 +86,35 @@ rm -rf ~/.local/share/Freenet ~/.config/Freenet ~/.cache/Freenet \
        ~/.cache/freenet ~/.local/state/freenet
 ```
 
-On macOS, the data, config, cache, and log directories live under `~/Library/Application Support/Freenet`, `~/Library/Caches/Freenet`, and `~/Library/Logs/Freenet` instead.
+**macOS.** The service is a launchd user agent and the data dirs use a bundle-ID layout, so the Linux snippet above doesn't apply. Instead:
 
-**Windows.** On Windows the PowerShell installer (`irm https://freenet.org/install.ps1 | iex`) lays things out a bit differently, and the bundled `freenet uninstall` has a known gap: it removes the data directory but may leave the config folder behind. After running the uninstall, delete these folders manually (PowerShell):
+```bash
+# Stop and remove the user agent
+launchctl unload ~/Library/LaunchAgents/org.freenet.node.plist 2>/dev/null
+rm -f ~/Library/LaunchAgents/org.freenet.node.plist
+
+# Remove binaries
+rm -f ~/.local/bin/freenet ~/.local/bin/fdev \
+      ~/.local/bin/freenet-service-wrapper.sh
+
+# Remove data, config, cache, and logs
+rm -rf ~/Library/Application\ Support/The-Freenet-Project-Inc.Freenet \
+       ~/Library/Caches/The-Freenet-Project-Inc.Freenet \
+       ~/Library/Caches/The-Freenet-Project-Inc.freenet \
+       ~/Library/Logs/freenet
+```
+
+**Windows.** The PowerShell installer (`irm https://freenet.org/install.ps1 | iex`) installs the binaries under `%LOCALAPPDATA%\Freenet\bin\`, and `freenet uninstall` has a known gap: it removes the data directory but may leave the config folder behind. After running the uninstall, delete any remaining folders manually (PowerShell):
 
 ```powershell
 # Binaries
 Remove-Item -Recurse -Force "$env:LOCALAPPDATA\Freenet\bin" -ErrorAction SilentlyContinue
 
-# Data (Local AppData)
+# Data and logs (Local AppData)
 Remove-Item -Recurse -Force "$env:LOCALAPPDATA\The Freenet Project Inc\Freenet" -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\freenet\logs" -ErrorAction SilentlyContinue
 
-# Config and logs (Roaming AppData)
+# Config (Roaming AppData)
 Remove-Item -Recurse -Force "$env:APPDATA\The Freenet Project Inc\Freenet" -ErrorAction SilentlyContinue
 ```
 


### PR DESCRIPTION
## Problem

A user on Matrix tried to uninstall Freenet with `sudo freenet uninstall` and got no output. Cause: the `curl -fsSL https://freenet.org/install.sh | sh` installer drops the binary in `~/.local/bin`, which isn't on `sudo`'s `secure_path`, so the command silently fails. `whereis` and `locate` don't cover user-local binaries either, so the user concluded Freenet was unremovable and left in frustration.

Our site currently has no user-facing documentation on how to uninstall — the install page tells people how to put Freenet on their machine but nothing about how to take it off.

## Approach

Defense-in-depth, documentation layer. Two additions:

1. **Quick Start guide** — an "Uninstalling" section explaining:
   - The `freenet uninstall` command and its `--purge` / `--keep-data` flags.
   - Why you should **not** prefix it with `sudo` for a normal install.
   - How to call it by full path if `~/.local/bin` isn't on `$PATH`.
   - How to clean up a `cargo install freenet` install.
   - A manual-fallback shell snippet that deletes the binaries, the systemd user unit, and the XDG data/config/cache/log directories when the binary is missing or broken. macOS paths noted.

2. **FAQ entry** at `/about/faq/#how-do-i-uninstall-freenet` covering the same ground more concisely and linking back to the Quick Start for the full walkthrough. Also added to the FAQ's in-page TOC.

Companion changes to freenet-core (standalone `uninstall.sh` script, clearer post-install message, having `freenet uninstall` also find `cargo install`-placed binaries) will follow in a separate PR.

## Testing

- `hugo` builds the site cleanly with the new content.
- Verified rendered HTML contains `<h2 id="uninstalling">` on the Quick Start page and `<h1 id="how-do-i-uninstall-freenet">` in the FAQ, so the new anchors are reachable and the Quick Start cross-link from the FAQ resolves.
- `git diff --stat` is 62 lines, all additions — no reformatting of unrelated content.

## Fixes

None — user-reported on Matrix, not tracked as a GitHub issue.

[AI-assisted - Claude]