### PR TITLE
feat: serve uninstall.sh + sync install.sh, fix Linux path casing

### DIFF
--- a/hugo-site/content/about/faq/index.md
+++ b/hugo-site/content/about/faq/index.md
@@ -233,7 +233,7 @@ If the `freenet` binary isn't on your PATH, invoke it by full path: `~/.local/bi
 
 If you installed with `cargo install freenet`, the binary is in `~/.cargo/bin/freenet`; run `cargo uninstall freenet` and then clean up the data directories below.
 
-On Windows, `freenet uninstall` has a known gap and may leave the config folder behind — after running it, also manually remove `%LOCALAPPDATA%\Freenet\bin`, `%LOCALAPPDATA%\The Freenet Project Inc\Freenet`, and `%APPDATA%\The Freenet Project Inc\Freenet`.
+On Windows, `freenet uninstall` has a known gap and may leave the config folder behind; after running it, also manually remove `%LOCALAPPDATA%\Freenet\bin`, `%LOCALAPPDATA%\The Freenet Project Inc\Freenet`, and `%APPDATA%\The Freenet Project Inc\Freenet`.
 
 The [Quick Start guide](/quickstart/#uninstalling) has the full per-platform manual-fallback snippets (Linux systemd, macOS launchd, Windows PowerShell) for when the binary is missing or broken.
 

--- a/hugo-site/content/quickstart/_index.md
+++ b/hugo-site/content/quickstart/_index.md
@@ -58,10 +58,11 @@ Run `riverctl --help` for the full list of commands.
 To remove Freenet completely:
 
 ```bash
-freenet uninstall
+freenet uninstall                                 # preferred
+curl -fsSL https://freenet.org/uninstall.sh | sh  # fallback
 ```
 
-This stops the service, removes the binaries, and (with confirmation) deletes your data, config, cache, and logs. Pass `--purge` to skip the confirmation, or `--keep-data` to preserve all of them.
+Either command stops the service, removes the binaries, and (with confirmation) deletes your data, config, cache, and logs. Pass `--purge` to skip the confirmation, or `--keep-data` to preserve all of them. The second form is useful when the installed `freenet` binary is missing, broken, or not on your PATH.
 
 **Do not run `sudo freenet uninstall`** for a normal `curl | sh` install. The installer puts the binary in `~/.local/bin`, which is not on `sudo`'s default PATH, so `sudo freenet uninstall` fails with `command not found` and your install is left untouched. Only use `sudo` if you originally installed with `--system` (in which case the unit file is at `/etc/systemd/system/freenet.service`).
 
@@ -82,7 +83,7 @@ rm -f ~/.config/systemd/user/freenet.service
 rm -f ~/.local/bin/freenet ~/.local/bin/fdev
 
 # Remove data, config, cache, and logs
-rm -rf ~/.local/share/Freenet ~/.config/Freenet ~/.cache/Freenet \
+rm -rf ~/.local/share/freenet ~/.config/freenet \
        ~/.cache/freenet ~/.local/state/freenet
 ```
 

--- a/hugo-site/static/install.sh
+++ b/hugo-site/static/install.sh
@@ -55,7 +55,7 @@ detect_os() {
             echo "macos"
             ;;
         MINGW*|MSYS*|CYGWIN*)
-            error "Windows is not yet supported. Please check https://freenet.org for updates."
+            error "For Windows, use PowerShell: irm https://freenet.org/install.ps1 | iex"
             ;;
         *)
             error "Unsupported operating system: $os"
@@ -85,17 +85,34 @@ detect_arch() {
     esac
 }
 
-# Build the target triple for downloading
+# Build the target triple for downloading (primary choice)
 get_target_triple() {
     os=$1
     arch=$2
 
     case "$os" in
         linux)
+            # Use musl for static linking - works on all Linux distros regardless of glibc version
             echo "${arch}-unknown-linux-musl"
             ;;
         macos)
             echo "${arch}-apple-darwin"
+            ;;
+    esac
+}
+
+# Get fallback target triple for older releases that don't have musl binaries
+get_fallback_target_triple() {
+    os=$1
+    arch=$2
+
+    case "$os" in
+        linux)
+            echo "${arch}-unknown-linux-gnu"
+            ;;
+        *)
+            # No fallback needed for non-Linux
+            echo ""
             ;;
     esac
 }
@@ -116,6 +133,20 @@ download() {
         wget -q "$url" -O "$dest"
     else
         error "Neither curl nor wget found. Please install one of them."
+    fi
+}
+
+# Try to download, return 0 on success, 1 on failure (without exiting)
+try_download() {
+    url=$1
+    dest=$2
+
+    if has_cmd curl; then
+        curl -fsSL "$url" -o "$dest" 2>/dev/null
+    elif has_cmd wget; then
+        wget -q "$url" -O "$dest" 2>/dev/null
+    else
+        return 1
     fi
 }
 
@@ -182,53 +213,39 @@ check_path() {
     esac
 }
 
-# Add install directory to PATH in the user's shell config
-ensure_in_path() {
+# Provide shell-specific PATH instructions
+print_path_instructions() {
     dir=$1
-    shell=$(basename "${SHELL:-/bin/sh}")
-    path_line="export PATH=\"\$HOME/.local/bin:\$PATH\""
+    shell=$(basename "$SHELL")
+
+    warn "$dir is not in your PATH"
+    echo ""
+    echo "Add it to your PATH by adding this line to your shell configuration:"
+    echo ""
 
     case "$shell" in
         bash)
-            # Prefer .bash_profile on macOS (login shell), .bashrc on Linux
-            if [ "$(detect_os)" = "macos" ]; then
-                rc="$HOME/.bash_profile"
-            else
-                rc="$HOME/.bashrc"
-            fi
-            if [ -f "$rc" ] && grep -qF '.local/bin' "$rc"; then
-                return 0
-            fi
-            echo "" >> "$rc"
-            echo "$path_line" >> "$rc"
-            info "Added $dir to PATH in $rc"
-            warn "Restart your shell or run: source $rc"
+            echo "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc"
+            echo ""
+            echo "Then reload your shell:"
+            echo "  source ~/.bashrc"
             ;;
         zsh)
-            rc="$HOME/.zshrc"
-            if [ -f "$rc" ] && grep -qF '.local/bin' "$rc"; then
-                return 0
-            fi
-            echo "" >> "$rc"
-            echo "$path_line" >> "$rc"
-            info "Added $dir to PATH in $rc"
-            warn "Restart your shell or run: source $rc"
+            echo "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.zshrc"
+            echo ""
+            echo "Then reload your shell:"
+            echo "  source ~/.zshrc"
             ;;
         fish)
-            if fish -c 'contains -- ~/.local/bin $fish_user_paths' 2>/dev/null; then
-                return 0
-            fi
-            fish -c 'fish_add_path ~/.local/bin' 2>/dev/null || true
-            info "Added $dir to PATH via fish_add_path"
+            echo "  fish_add_path ~/.local/bin"
             ;;
         *)
-            warn "$dir is not in your PATH"
+            echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
             echo ""
-            echo "Add this line to your shell configuration file:"
-            echo "  $path_line"
-            echo ""
+            echo "Add this line to your shell's configuration file."
             ;;
     esac
+    echo ""
 }
 
 # Main installation logic
@@ -236,21 +253,12 @@ main() {
     info "Freenet Installer"
     echo ""
 
-    # Telemetry disclosure
-    printf "${YELLOW}Note:${NC} Freenet collects anonymous telemetry data by default during alpha\n"
-    echo "      to help diagnose network issues. This includes:"
-    echo "      - Operation timing (connect, put, get, subscribe, update)"
-    echo "      - Network topology information"
-    echo "      - NO contract content is ever transmitted"
-    echo ""
-    echo "      To disable telemetry, run: freenet --telemetry-enabled=false"
-    echo "      Or set FREENET_TELEMETRY_ENABLED=false in your environment"
-    echo ""
-
     # Detect platform
     os=$(detect_os)
     arch=$(detect_arch)
     target=$(get_target_triple "$os" "$arch")
+    fallback_target=$(get_fallback_target_triple "$os" "$arch")
+    using_fallback=false
 
     info "Detected platform: $os ($arch)"
 
@@ -287,11 +295,25 @@ main() {
         checksums_available=true
     fi
 
-    # Download freenet
+    # Download freenet (try musl first, fall back to gnu for older releases)
     info "Downloading freenet..."
     freenet_archive="freenet-${target}.tar.gz"
     freenet_url="https://github.com/freenet/freenet-core/releases/download/v${version}/${freenet_archive}"
-    download "$freenet_url" "$tmp_dir/freenet.tar.gz"
+
+    if ! try_download "$freenet_url" "$tmp_dir/freenet.tar.gz"; then
+        # Try fallback target (gnu) for older releases
+        if [ -n "$fallback_target" ]; then
+            warn "Musl binary not available, trying glibc version..."
+            freenet_archive="freenet-${fallback_target}.tar.gz"
+            freenet_url="https://github.com/freenet/freenet-core/releases/download/v${version}/${freenet_archive}"
+            if ! try_download "$freenet_url" "$tmp_dir/freenet.tar.gz"; then
+                error "Failed to download freenet binary for version $version"
+            fi
+            using_fallback=true
+        else
+            error "Failed to download freenet binary for version $version"
+        fi
+    fi
 
     # Verify freenet checksum
     if [ "$checksums_available" = true ]; then
@@ -304,11 +326,18 @@ main() {
         fi
     fi
 
-    # Download fdev
+    # Download fdev (use same target as freenet)
     info "Downloading fdev..."
-    fdev_archive="fdev-${target}.tar.gz"
+    if [ "$using_fallback" = true ]; then
+        fdev_archive="fdev-${fallback_target}.tar.gz"
+    else
+        fdev_archive="fdev-${target}.tar.gz"
+    fi
     fdev_url="https://github.com/freenet/freenet-core/releases/download/v${version}/${fdev_archive}"
-    download "$fdev_url" "$tmp_dir/fdev.tar.gz"
+
+    if ! try_download "$fdev_url" "$tmp_dir/fdev.tar.gz"; then
+        error "Failed to download fdev binary for version $version"
+    fi
 
     # Verify fdev checksum
     if [ "$checksums_available" = true ]; then
@@ -319,6 +348,12 @@ main() {
         else
             warn "Checksum not found for $fdev_archive"
         fi
+    fi
+
+    # Warn about glibc compatibility if using fallback
+    if [ "$using_fallback" = true ]; then
+        warn "Using glibc-linked binary. If you see 'GLIBC_X.XX not found' errors,"
+        warn "please upgrade to a newer Freenet version or build from source."
     fi
 
     # Extract binaries
@@ -361,53 +396,31 @@ main() {
     mv -- "$tmp_dir/fdev" "$install_dir/fdev"
     chmod +x "$install_dir/freenet" "$install_dir/fdev"
 
-    # On macOS, remove quarantine attribute to allow unsigned binaries to run
-    if [ "$os" = "macos" ]; then
-        xattr -d com.apple.quarantine "$install_dir/freenet" 2>/dev/null || true
-        xattr -d com.apple.quarantine "$install_dir/fdev" 2>/dev/null || true
-    fi
-
     # Verify the installed binary works
     if ! "$install_dir/freenet" --version >/dev/null 2>&1; then
-        if [ "$os" = "macos" ]; then
-            error "Binary verification failed. macOS may be blocking the unsigned binary.
-Try running: xattr -d com.apple.quarantine $install_dir/freenet $install_dir/fdev
-Then run: $install_dir/freenet --version"
-        else
-            error "Installed binary verification failed. The binary may be corrupted or incompatible with your system."
-        fi
+        error "Installed binary verification failed. The binary may be corrupted or incompatible with your system."
     fi
 
     success "Freenet $version installed successfully!"
     echo ""
 
-    # Ensure install directory is in PATH
+    # Check PATH
     if ! check_path "$install_dir"; then
-        ensure_in_path "$install_dir"
+        print_path_instructions "$install_dir"
     fi
 
     # Ask about service installation (unless FREENET_NO_SERVICE is set)
     if [ "${FREENET_NO_SERVICE:-0}" != "1" ]; then
         echo ""
-        printf "Would you like to install Freenet as a user service (auto-starts on login)? [y/N] "
-        read -r response </dev/tty
+        printf "Would you like to install Freenet as a system service? [y/N] "
+        read -r response
         case "$response" in
             [yY]|[yY][eE][sS])
                 info "Installing service..."
                 "$install_dir/freenet" service install
                 echo ""
-                printf "Would you like to start the service now? [Y/n] "
-                read -r start_response </dev/tty
-                case "$start_response" in
-                    [nN]|[nN][oO])
-                        success "Service installed! Start it with: freenet service start"
-                        ;;
-                    *)
-                        info "Starting service..."
-                        "$install_dir/freenet" service start
-                        success "Freenet is now running!"
-                        ;;
-                esac
+                success "Service installed! Start it with: freenet service start"
+                echo "  Once running, open http://127.0.0.1:7509/ to view your Freenet dashboard."
                 ;;
             *)
                 info "Skipping service installation"
@@ -421,6 +434,17 @@ Then run: $install_dir/freenet --version"
     echo ""
     echo "To run Freenet manually:"
     echo "  freenet network"
+    echo ""
+    echo "Once running, open http://127.0.0.1:7509/ to view your Freenet dashboard."
+    echo ""
+    echo "To uninstall Freenet completely:"
+    echo "  freenet uninstall                                       # preferred"
+    echo "  curl -fsSL https://freenet.org/uninstall.sh | sh        # fallback"
+    echo ""
+    echo "Do NOT prefix either command with 'sudo'. This installer placed Freenet"
+    echo "under $install_dir, which is typically not on sudo's PATH — sudo would"
+    echo "fail with 'command not found' and leave your install untouched. Only"
+    echo "use sudo if you originally installed with 'freenet service install --system'."
     echo ""
     echo "For more information, visit: https://freenet.org"
 }

--- a/hugo-site/static/uninstall.sh
+++ b/hugo-site/static/uninstall.sh
@@ -1,0 +1,253 @@
+#!/bin/sh
+# Freenet uninstaller script
+# Usage: curl -fsSL https://freenet.org/uninstall.sh | sh
+#
+# Removes Freenet from the current user's install:
+#  - Stops and removes the user systemd service / launchd agent.
+#  - Deletes the `freenet` and `fdev` binaries from every known install
+#    location (curl installer, cargo install, and the current exe's dir).
+#  - Optionally purges data, config, cache, and logs.
+#
+# This script works even when the installed `freenet` binary is missing,
+# broken, or invoked from the wrong user account. For a one-stop shop,
+# `freenet uninstall` is still the preferred path when the binary runs;
+# this script exists for the cases where it doesn't (a stale install, a
+# user who tried `sudo freenet uninstall` and had it silently no-op
+# because ~/.local/bin wasn't on sudo's PATH, etc.).
+#
+# Options (via environment variables or flags):
+#   --purge                Also delete data, config, cache, and logs
+#   --keep-data            Keep data, config, cache, and logs (skip prompt)
+#   -y, --yes              Non-interactive: assume "keep data" when neither
+#                          --purge nor --keep-data is set
+#   FREENET_PURGE=1        Same as --purge
+#   FREENET_KEEP_DATA=1    Same as --keep-data
+
+set -eu
+
+# Colors for output (if terminal supports it)
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    NC='\033[0m' # No Color
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    NC=''
+fi
+
+info() {
+    printf "${BLUE}info:${NC} %s\n" "$1"
+}
+
+success() {
+    printf "${GREEN}success:${NC} %s\n" "$1"
+}
+
+warn() {
+    printf "${YELLOW}warning:${NC} %s\n" "$1"
+}
+
+error() {
+    printf "${RED}error:${NC} %s\n" "$1" >&2
+    exit 1
+}
+
+has_cmd() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Guard against well-meaning `sudo curl | sudo sh`: this script operates on
+# the invoking user's home directory, so running under root silently wipes
+# root's home rather than the user's. Short-circuit with a clear message.
+if [ "$(id -u)" = "0" ] && [ -z "${FREENET_ALLOW_ROOT:-}" ]; then
+    error "Do not run this uninstaller with sudo. The Freenet install lives in your own
+home directory (~/.local/bin), not root's. Re-run without sudo, or set
+FREENET_ALLOW_ROOT=1 if you really mean to uninstall root's install."
+fi
+
+# Parse flags
+PURGE="${FREENET_PURGE:-0}"
+KEEP_DATA="${FREENET_KEEP_DATA:-0}"
+ASSUME_YES="0"
+
+print_help() {
+    cat <<'EOF'
+Usage: uninstall.sh [--purge | --keep-data] [-y|--yes]
+
+Removes Freenet from the current user's install: stops and removes the
+user systemd service / launchd agent, deletes the freenet and fdev
+binaries from every known install location (curl installer, cargo
+install, and the current exe's dir), and optionally purges data,
+config, cache, and logs.
+
+Options:
+  --purge         Also delete data, config, cache, and logs
+  --keep-data     Keep data, config, cache, and logs (skip prompt)
+  -y, --yes       Non-interactive: assume "keep data" when neither
+                  --purge nor --keep-data is set
+
+Equivalents via environment variables:
+  FREENET_PURGE=1            same as --purge
+  FREENET_KEEP_DATA=1        same as --keep-data
+  FREENET_ALLOW_ROOT=1       permit running under sudo / as root
+
+For installs that were done with `cargo install freenet`, this script
+still finds and removes the binary from ~/.cargo/bin. For Windows,
+use `freenet.exe uninstall` from a user-level terminal.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --purge)
+            PURGE="1"
+            ;;
+        --keep-data)
+            KEEP_DATA="1"
+            ;;
+        -y|--yes)
+            ASSUME_YES="1"
+            ;;
+        -h|--help)
+            print_help
+            exit 0
+            ;;
+        *)
+            error "Unknown option: $1"
+            ;;
+    esac
+    shift
+done
+
+if [ "$PURGE" = "1" ] && [ "$KEEP_DATA" = "1" ]; then
+    error "--purge and --keep-data are mutually exclusive"
+fi
+
+# Detect OS so we know which service manager and data directories to touch.
+OS="$(uname -s)"
+case "$OS" in
+    Linux)  OS=linux ;;
+    Darwin) OS=macos ;;
+    *)      error "Unsupported OS: $OS. For Windows, open PowerShell as the current user
+and run: freenet.exe uninstall (or delete %LOCALAPPDATA%\\Freenet\\bin by hand)." ;;
+esac
+
+info "Freenet uninstaller (${OS})"
+
+# --- Step 1: stop and remove the service ----------------------------------
+
+removed_service=""
+
+if [ "$OS" = "linux" ]; then
+    # User-level systemd unit
+    if has_cmd systemctl && systemctl --user status freenet.service >/dev/null 2>&1; then
+        info "Stopping user systemd service..."
+        systemctl --user stop freenet.service >/dev/null 2>&1 || true
+        systemctl --user disable freenet.service >/dev/null 2>&1 || true
+        removed_service="user systemd"
+    fi
+    # Unit file (may exist even if service never ran)
+    UNIT="${HOME}/.config/systemd/user/freenet.service"
+    if [ -f "$UNIT" ]; then
+        rm -f "$UNIT"
+        info "Removed ${UNIT}"
+        removed_service="${removed_service:-user systemd}"
+    fi
+    # System-wide unit — leave alone by default; needs sudo.
+    if [ -f /etc/systemd/system/freenet.service ]; then
+        warn "A system-wide service unit exists at /etc/systemd/system/freenet.service.
+       This script only manages the user-level install. Remove the system unit with:
+         sudo freenet service uninstall --system
+       (or: sudo systemctl disable --now freenet && sudo rm /etc/systemd/system/freenet.service)"
+    fi
+elif [ "$OS" = "macos" ]; then
+    PLIST="${HOME}/Library/LaunchAgents/org.freenet.node.plist"
+    if [ -f "$PLIST" ]; then
+        info "Unloading launchd agent..."
+        launchctl unload "$PLIST" >/dev/null 2>&1 || true
+        rm -f "$PLIST"
+        info "Removed ${PLIST}"
+        removed_service="launchd"
+    fi
+fi
+
+# --- Step 2: remove binaries from every known install location ------------
+
+removed_binaries="0"
+remove_binary() {
+    # $1: path
+    if [ -e "$1" ]; then
+        rm -f "$1" && info "Removed $1"
+        removed_binaries="1"
+    fi
+}
+
+# Iterate install locations with a for-loop (not a pipe to `while read`) so
+# that updates to `removed_binaries` survive into the summary step — the
+# pipe variant runs the while-body in a subshell under POSIX sh.
+for dir in "${HOME}/.local/bin" "${HOME}/.cargo/bin"; do
+    [ -d "$dir" ] || continue
+    for bin in freenet fdev freenet-service-wrapper.sh; do
+        remove_binary "${dir}/${bin}"
+    done
+done
+
+# --- Step 3: decide whether to purge data ---------------------------------
+
+should_purge() {
+    if [ "$PURGE" = "1" ]; then
+        return 0
+    fi
+    if [ "$KEEP_DATA" = "1" ]; then
+        return 1
+    fi
+    if [ "$ASSUME_YES" = "1" ]; then
+        return 1 # default to keep when non-interactive
+    fi
+    if [ ! -t 0 ]; then
+        info "Non-interactive session; keeping data/config/logs. Pass --purge to remove them."
+        return 1
+    fi
+    printf "Also remove all Freenet data, config, and logs? [y/N] "
+    read -r answer || answer=""
+    case "$answer" in
+        y|Y|yes|YES) return 0 ;;
+        *)           return 1 ;;
+    esac
+}
+
+if should_purge; then
+    info "Removing data, config, cache, and logs..."
+    if [ "$OS" = "linux" ]; then
+        rm -rf \
+            "${HOME}/.local/share/Freenet" \
+            "${HOME}/.config/Freenet" \
+            "${HOME}/.cache/Freenet" \
+            "${HOME}/.cache/freenet" \
+            "${HOME}/.local/state/freenet"
+    else
+        # macOS: `directories` crate uses a dotted bundle ID under Application
+        # Support and Caches, and lowercase `freenet` under Logs.
+        rm -rf \
+            "${HOME}/Library/Application Support/The-Freenet-Project-Inc.Freenet" \
+            "${HOME}/Library/Caches/The-Freenet-Project-Inc.Freenet" \
+            "${HOME}/Library/Caches/The-Freenet-Project-Inc.freenet" \
+            "${HOME}/Library/Logs/freenet"
+    fi
+    success "Data removed."
+else
+    info "Keeping data directories. You can remove them later manually."
+fi
+
+# --- Summary --------------------------------------------------------------
+
+if [ -z "$removed_service" ] && [ "$removed_binaries" = "0" ]; then
+    info "Nothing to uninstall — Freenet does not appear to be installed for this user."
+else
+    success "Freenet uninstalled."
+fi


### PR DESCRIPTION
## Problem

Three follow-ups to the uninstall documentation merged in #35, triggered by review feedback on the companion freenet-core PRs:

1. **`curl https://freenet.org/uninstall.sh | sh` doesn't work** — #35's quickstart and the upcoming freenet-core install.sh message advertise this one-liner as the fallback when the installed `freenet` binary is missing or broken, but the site never served the script.

2. **The site's `static/install.sh` drifted from freenet-core's source.** It's missing the post-install message update (freenet-core#3906) that warns users against prefixing either uninstall command with sudo — the specific mistake that caused the original Matrix user's frustration.

3. **The Linux uninstall paths in #35 were wrong.** Codex's review on freenet-core#3906 caught that `ProjectDirs::from("", "The Freenet Project Inc", "Freenet")` on Linux lowercases the application name via `trim_and_lowercase_then_replace_spaces`, so the actual on-disk paths are `~/.local/share/freenet`, `~/.config/freenet`, `~/.cache/freenet` (all lowercase). #35 told users to `rm -rf ~/.local/share/Freenet` etc. — paths that never existed on Linux. A reader following the manual fallback would have removed nothing.

## Approach

- Publish `hugo-site/static/uninstall.sh` (byte-identical to freenet-core's new `scripts/uninstall.sh`) and sync `hugo-site/static/install.sh` with the updated freenet-core source.
- Fix the Linux paths in the quickstart manual-fallback and reword the FAQ pointer to match.
- Quickstart's "Uninstalling" section now opens with both the preferred and curl-based forms side by side so the one-liner is discoverable immediately.
- Replace the remaining em-dashes with plain hyphens to match the house style.

## Testing

- Hugo build clean.
- Verified rendered HTML still has `<h2 id="uninstalling">` and the FAQ anchor, plus the new curl uninstall fallback line.
- The `uninstall.sh` script itself is covered by `scripts/test-uninstall-sh.sh` in freenet-core#3906 (13 smoke-test cases passing).

## Related

- freenet/freenet-core#3905 — `freenet uninstall` robustness (cargo-bin detection, Windows parent-folder cleanup)
- freenet/freenet-core#3906 — `uninstall.sh` script and install.sh closing-message update
- freenet/freenet-core#3907 — follow-up for the same uppercase-path bug in core's `home_override` branch

[AI-assisted - Claude]