### PR TITLE
docs(quickstart): link macOS to signed DMG instead of install.sh

### DIFF
--- a/hugo-site/content/quickstart/_index.md
+++ b/hugo-site/content/quickstart/_index.md
@@ -87,10 +87,24 @@ rm -rf ~/.local/share/freenet ~/.config/freenet \
        ~/.cache/freenet ~/.local/state/freenet
 ```
 
-**macOS.** The service is a launchd user agent and the data dirs use a bundle-ID layout, so the Linux snippet above doesn't apply. Instead:
+**macOS (DMG install).** Click the menu bar rabbit → **Quit Freenet**, then drag `Freenet.app` from `/Applications` to the Trash. To also remove data and configuration:
 
 ```bash
-# Stop and remove the user agent
+# Remove the launch-at-login agent
+launchctl bootout gui/$UID/org.freenet.Freenet 2>/dev/null
+rm -f ~/Library/LaunchAgents/org.freenet.Freenet.plist
+
+# Remove data, config, cache, and logs
+rm -rf ~/Library/Application\ Support/The-Freenet-Project-Inc.Freenet \
+       ~/Library/Caches/The-Freenet-Project-Inc.Freenet \
+       ~/Library/Caches/Freenet \
+       ~/Library/Logs/freenet
+```
+
+**macOS (legacy `install.sh` install).** Older installs use the `org.freenet.node` agent and binaries under `~/.local/bin`:
+
+```bash
+# Stop and remove the legacy user agent
 launchctl unload ~/Library/LaunchAgents/org.freenet.node.plist 2>/dev/null
 rm -f ~/Library/LaunchAgents/org.freenet.node.plist
 

--- a/hugo-site/layouts/shortcodes/os-install.html
+++ b/hugo-site/layouts/shortcodes/os-install.html
@@ -100,9 +100,11 @@
     </div>
 
     <div class="tab-pane" data-os="mac" role="tabpanel" id="os-pane-mac" aria-labelledby="os-tab-mac">
-        <p>Run this command in your terminal:</p>
-        <pre><code class="language-bash">curl -fsSL https://freenet.org/install.sh | sh</code></pre>
-        <p>This downloads and installs Freenet, then starts it as a background service.</p>
+        <p><a href="https://github.com/freenet/freenet-core/releases/latest/download/Freenet.dmg">Download Freenet.dmg</a>,
+        open it, and drag <strong>Freenet</strong> into <strong>Applications</strong>. Launch it from
+        Launchpad or Spotlight &mdash; a rabbit icon appears in the menu bar, and Freenet will start
+        automatically at login from then on.</p>
+        <p>The DMG is signed and notarized by Apple, so macOS opens it without Gatekeeper warnings.</p>
     </div>
 
     <div class="tab-pane active" data-os="linux" role="tabpanel" id="os-pane-linux" aria-labelledby="os-tab-linux">


### PR DESCRIPTION
## Problem

The quickstart page sent Mac users to `curl -fsSL https://freenet.org/install.sh | sh`, which leaves them with a background process, no menu bar icon, no "it's installed" moment, and no auto-update on macOS. With v0.2.49 we now ship a signed, notarized Freenet.app inside a DMG — that should be the intended Mac flow.

## Solution

- macOS install tab now points to `https://github.com/freenet/freenet-core/releases/latest/download/Freenet.dmg` with "open → drag to Applications → menu bar rabbit" instructions.
- Uninstall section split in two:
  - **DMG install:** drag Freenet.app to Trash + `launchctl bootout gui/\$UID/org.freenet.Freenet` + remove `org.freenet.Freenet.plist` + remove Library dirs.
  - **Legacy `install.sh` install:** unchanged old snippet (still applies to users who installed before v0.2.49).

The stable DMG URL is backed by a companion freenet-core workflow change that uploads both `Freenet-X.Y.Z.dmg` and `Freenet.dmg` on every release; a versionless copy has been retro-uploaded to v0.2.49 so the URL works today.

## Testing

- `hugo --minify` clean build (106 pages, 720ms, no errors).
- Inspected rendered `/quickstart/index.html` — Mac tab anchor points to `.../releases/latest/download/Freenet.dmg`.
- Verified the URL returns 200 (retro-uploaded to v0.2.49 release).

[AI-assisted - Claude]