### PR TITLE
docs(quickstart): slim page, add /uninstall/, warn install.sh migrators

### DIFF
--- a/hugo-site/content/about/faq/index.md
+++ b/hugo-site/content/about/faq/index.md
@@ -237,7 +237,7 @@ If you installed with `cargo install freenet`, the binary is in `~/.cargo/bin/fr
 
 On Windows, `freenet uninstall` has a known gap and may leave the config folder behind; after running it, also manually remove `%LOCALAPPDATA%\Freenet\bin`, `%LOCALAPPDATA%\The Freenet Project Inc\Freenet`, and `%APPDATA%\The Freenet Project Inc\Freenet`.
 
-The [Quick Start guide](/quickstart/#uninstalling) has the full per-platform manual-fallback snippets (Linux systemd, macOS launchd, Windows PowerShell) for when the binary is missing or broken.
+The [Uninstall guide](/uninstall/) has the full per-platform manual-fallback snippets (Linux systemd, macOS launchd, Windows PowerShell) for when the binary is missing or broken.
 
 # Why does the Freenet project use and mention AI tools? {#why-does-the-freenet-project-use-and-mention-ai-tools}
 

--- a/hugo-site/content/quickstart/_index.md
+++ b/hugo-site/content/quickstart/_index.md
@@ -25,127 +25,30 @@ River is our decentralized group chat, built on Freenet. Click below to get an i
 
 {{< river-invite-button room="Freenet Official" >}}
 
-Clicking the link will open River in your browser and automatically join you to the room using the invite
-code.
+Clicking the link opens River in your browser and automatically joins you to the room using
+the invite code.
 
-### CLI Alternative: riverctl
-
-River also has a full-featured command-line interface. If you have Rust tooling installed, you can install it
-with:
-
-```bash
-cargo install riverctl
-```
-
-To accept an invite via the CLI, click "Get Invite Code" above, expand "Using riverctl? Copy invite code" to
-copy the code, then run:
-
-```bash
-riverctl invite accept <invite-code>
-```
-
-Once joined, you can send and receive messages entirely from the terminal:
-
-```bash
-riverctl message send <room-owner-key> "Hello from the CLI!"
-riverctl message stream <room-owner-key>   # live message stream
-riverctl room list                          # list your rooms
-```
-
-Run `riverctl --help` for the full list of commands.
-
-## Uninstalling
-
-To remove Freenet completely:
-
-```bash
-freenet uninstall                                 # preferred
-curl -fsSL https://freenet.org/uninstall.sh | sh  # fallback
-```
-
-Either command stops the service, removes the binaries, and (with confirmation) deletes your data, config, cache, and logs. Pass `--purge` to skip the confirmation, or `--keep-data` to preserve all of them. The second form is useful when the installed `freenet` binary is missing, broken, or not on your PATH.
-
-**Do not run `sudo freenet uninstall`** for a normal `curl | sh` install. The installer puts the binary in `~/.local/bin`, which is not on `sudo`'s default PATH, so `sudo freenet uninstall` fails with `command not found` and your install is left untouched. Only use `sudo` if you originally installed with `--system` (in which case the unit file is at `/etc/systemd/system/freenet.service`).
-
-If `freenet` isn't on your PATH, call it by full path: `~/.local/bin/freenet uninstall`.
-
-**Installed with `cargo install freenet`?** The binary lives in `~/.cargo/bin/freenet`. Run `cargo uninstall freenet` (and `cargo uninstall fdev` if you also installed that), then remove the data directories listed below.
-
-### Manual fallback
-
-If the binary is missing or broken, remove everything by hand:
-
-```bash
-# Stop and remove the user service (if installed)
-systemctl --user disable --now freenet.service 2>/dev/null
-rm -f ~/.config/systemd/user/freenet.service
-
-# Remove binaries
-rm -f ~/.local/bin/freenet ~/.local/bin/fdev
-
-# Remove data, config, cache, and logs
-rm -rf ~/.local/share/freenet ~/.config/freenet \
-       ~/.cache/freenet ~/.local/state/freenet
-```
-
-**macOS (DMG install).** Click the menu bar rabbit → **Quit Freenet**, then drag `Freenet.app` from `/Applications` to the Trash. To also remove data and configuration:
-
-```bash
-# Remove the launch-at-login agent
-launchctl bootout gui/$UID/org.freenet.Freenet 2>/dev/null
-rm -f ~/Library/LaunchAgents/org.freenet.Freenet.plist
-
-# Remove data, config, cache, and logs
-rm -rf ~/Library/Application\ Support/The-Freenet-Project-Inc.Freenet \
-       ~/Library/Caches/The-Freenet-Project-Inc.Freenet \
-       ~/Library/Caches/Freenet \
-       ~/Library/Logs/freenet
-```
-
-**macOS (legacy `install.sh` install).** Older installs use the `org.freenet.node` agent and binaries under `~/.local/bin`:
-
-```bash
-# Stop and remove the legacy user agent
-launchctl unload ~/Library/LaunchAgents/org.freenet.node.plist 2>/dev/null
-rm -f ~/Library/LaunchAgents/org.freenet.node.plist
-
-# Remove binaries
-rm -f ~/.local/bin/freenet ~/.local/bin/fdev \
-      ~/.local/bin/freenet-service-wrapper.sh
-
-# Remove data, config, cache, and logs
-rm -rf ~/Library/Application\ Support/The-Freenet-Project-Inc.Freenet \
-       ~/Library/Caches/The-Freenet-Project-Inc.Freenet \
-       ~/Library/Caches/The-Freenet-Project-Inc.freenet \
-       ~/Library/Logs/freenet
-```
-
-**Windows.** The PowerShell installer (`irm https://freenet.org/install.ps1 | iex`) installs the binaries under `%LOCALAPPDATA%\Freenet\bin\`, and `freenet uninstall` has a known gap: it removes the data directory but may leave the config folder behind. After running the uninstall, delete any remaining folders manually (PowerShell):
-
-```powershell
-# Binaries
-Remove-Item -Recurse -Force "$env:LOCALAPPDATA\Freenet\bin" -ErrorAction SilentlyContinue
-
-# Data and logs (Local AppData)
-Remove-Item -Recurse -Force "$env:LOCALAPPDATA\The Freenet Project Inc\Freenet" -ErrorAction SilentlyContinue
-Remove-Item -Recurse -Force "$env:LOCALAPPDATA\freenet\logs" -ErrorAction SilentlyContinue
-
-# Config (Roaming AppData)
-Remove-Item -Recurse -Force "$env:APPDATA\The Freenet Project Inc\Freenet" -ErrorAction SilentlyContinue
-```
-
-Also check `HKCU:\Software\Microsoft\Windows\CurrentVersion\Run` in the registry for any leftover `Freenet` startup entry and remove it.
+Prefer the terminal? River has a full-featured CLI, `riverctl`. See the
+[riverctl README](https://github.com/freenet/river/blob/main/cli/README.md) for install and
+usage.
 
 ## Troubleshooting
 
 If you run into problems, join our [Matrix chat](https://matrix.to/#/#freenet-locutus:matrix.org) for help.
 
-**Invite didn't work?** If River opened but you're not in the room, try restarting Freenet (`freenet service restart`), then come back to this page and click the invite button again for a fresh invite code. If you see the room but can't send messages, click the **"i"** icon next to the room name, click **"Leave Room"**, then get a new invite.
+**Invite didn't work?** If River opened but you're not in the room, try restarting Freenet
+(`freenet service restart`), then come back to this page and click the invite button again for
+a fresh invite code. If you see the room but can't send messages, click the **"i"** icon next to
+the room name, click **"Leave Room"**, then get a new invite.
 
-**Containers & headless servers:** If service installation fails (common in LXC/Docker), use the system-wide
-service instead: `sudo freenet service install --system`
+**Containers & headless servers:** If service installation fails (common in LXC/Docker), use
+the system-wide service instead: `sudo freenet service install --system`
 
-**Network requirements:** Freenet uses UDP hole punching for peer-to-peer connections. Most home routers support this without configuration. Strict corporate firewalls may block connections.
+**Network requirements:** Freenet uses UDP hole punching for peer-to-peer connections. Most
+home routers support this without configuration. Strict corporate firewalls may block
+connections.
+
+Need to remove Freenet? See the [uninstall guide](/uninstall/).
 
 ## What's Next?
 

--- a/hugo-site/content/uninstall/_index.md
+++ b/hugo-site/content/uninstall/_index.md
@@ -1,0 +1,93 @@
+---
+title: "Uninstalling Freenet"
+date: 2026-04-22
+draft: false
+---
+
+Pick the install method you used. If you're not sure, the **DMG / installer** sections cover the most common case on macOS and Windows.
+
+## macOS (DMG install)
+
+Click the menu bar rabbit, choose **Quit Freenet**, and drag `Freenet.app` from `/Applications` to the Trash. To also remove data and configuration:
+
+```bash
+# Remove the launch-at-login agent
+launchctl bootout gui/$UID/org.freenet.Freenet 2>/dev/null
+rm -f ~/Library/LaunchAgents/org.freenet.Freenet.plist
+
+# Remove data, config, cache, and logs
+rm -rf ~/Library/Application\ Support/The-Freenet-Project-Inc.Freenet \
+       ~/Library/Caches/The-Freenet-Project-Inc.Freenet \
+       ~/Library/Caches/Freenet \
+       ~/Library/Logs/freenet
+```
+
+## macOS (legacy `install.sh` install)
+
+Older installs use the `org.freenet.node` agent and binaries under `~/.local/bin`:
+
+```bash
+# Stop and remove the legacy user agent
+launchctl unload ~/Library/LaunchAgents/org.freenet.node.plist 2>/dev/null
+rm -f ~/Library/LaunchAgents/org.freenet.node.plist
+
+# Remove binaries
+rm -f ~/.local/bin/freenet ~/.local/bin/fdev \
+      ~/.local/bin/freenet-service-wrapper.sh
+
+# Remove data, config, cache, and logs
+rm -rf ~/Library/Application\ Support/The-Freenet-Project-Inc.Freenet \
+       ~/Library/Caches/The-Freenet-Project-Inc.Freenet \
+       ~/Library/Caches/The-Freenet-Project-Inc.freenet \
+       ~/Library/Logs/freenet
+```
+
+## Windows
+
+The PowerShell installer (`irm https://freenet.org/install.ps1 | iex`) places binaries under `%LOCALAPPDATA%\Freenet\bin\`. `freenet uninstall` removes the data directory but may leave the config folder behind, so do a manual pass afterward (PowerShell):
+
+```powershell
+# Binaries
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\Freenet\bin" -ErrorAction SilentlyContinue
+
+# Data and logs (Local AppData)
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\The Freenet Project Inc\Freenet" -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\freenet\logs" -ErrorAction SilentlyContinue
+
+# Config (Roaming AppData)
+Remove-Item -Recurse -Force "$env:APPDATA\The Freenet Project Inc\Freenet" -ErrorAction SilentlyContinue
+```
+
+Also check `HKCU:\Software\Microsoft\Windows\CurrentVersion\Run` in the registry for a leftover `Freenet` startup entry and remove it.
+
+## Linux
+
+```bash
+freenet uninstall                                 # preferred
+curl -fsSL https://freenet.org/uninstall.sh | sh  # fallback
+```
+
+Either command stops the service, removes the binaries, and (with confirmation) deletes your data, config, cache, and logs. Pass `--purge` to skip the confirmation, or `--keep-data` to preserve those files. The second form is useful when the installed `freenet` binary is missing, broken, or not on your PATH.
+
+**Do not run `sudo freenet uninstall`** for a normal `curl | sh` install. The installer puts the binary in `~/.local/bin`, which is not on `sudo`'s default PATH, so `sudo freenet uninstall` fails with `command not found` and your install is left untouched. Only use `sudo` if you originally installed with `--system` (the unit file lives at `/etc/systemd/system/freenet.service`).
+
+If `freenet` isn't on your PATH, call it by full path: `~/.local/bin/freenet uninstall`.
+
+**Installed with `cargo install freenet`?** The binary lives in `~/.cargo/bin/freenet`. Run `cargo uninstall freenet` (and `cargo uninstall fdev` if you also installed that), then remove the data directories below.
+
+### Manual fallback
+
+If the binary is missing or broken, remove everything by hand:
+
+```bash
+# Stop and remove the user service (if installed)
+systemctl --user disable --now freenet.service 2>/dev/null
+rm -f ~/.config/systemd/user/freenet.service
+
+# Remove binaries
+rm -f ~/.local/bin/freenet ~/.local/bin/fdev
+
+# Remove data, config, cache, and logs
+rm -rf ~/.local/share/freenet ~/.config/freenet \
+       ~/.cache/freenet ~/.local/state/freenet
+```

--- a/hugo-site/layouts/shortcodes/os-install.html
+++ b/hugo-site/layouts/shortcodes/os-install.html
@@ -88,6 +88,19 @@
     box-shadow: 0 0 0 4px rgba(0, 102, 204, 0.5), 0 6px 20px rgba(0, 102, 204, 0.35);
 }
 
+.os-install-tabs .install-note {
+    margin-top: 0.75rem;
+    padding: 0.75rem 1rem;
+    border-left: 3px solid #0066CC;
+    background: rgba(0, 102, 204, 0.06);
+    border-radius: 0 6px 6px 0;
+    font-size: 0.95rem;
+}
+
+.os-install-tabs .install-note strong {
+    color: #004C99;
+}
+
 .os-install-tabs .download-btn svg {
     width: 1.25em;
     height: 1.25em;
@@ -110,6 +123,15 @@
 
     .os-install-tabs .tab-btn.active {
         border-bottom-color: #4da6ff;
+    }
+
+    .os-install-tabs .install-note {
+        border-left-color: #4da6ff;
+        background: rgba(77, 166, 255, 0.08);
+    }
+
+    .os-install-tabs .install-note strong {
+        color: #4da6ff;
     }
 
     .os-install-tabs .download-btn {
@@ -160,6 +182,11 @@
         <p>Open the DMG and drag <strong>Freenet</strong> into <strong>Applications</strong>. Launch
         it from Launchpad or Spotlight. A rabbit icon appears in the menu bar, and Freenet starts
         automatically at login from then on.</p>
+        <div class="install-note">
+            <strong>Already installed Freenet via <code>install.sh</code>?</strong>
+            Uninstall the old version first so it doesn't conflict with the new app. See the
+            <a href="/uninstall/#macos-legacy-installsh-install">legacy macOS uninstall steps</a>.
+        </div>
     </div>
 
     <div class="tab-pane active" data-os="linux" role="tabpanel" id="os-pane-linux" aria-labelledby="os-tab-linux">


### PR DESCRIPTION
## Problem

Quickstart was 142 lines on a page new users land on. Roughly half of that was uninstall/cleanup scripts (macOS Library paths, Windows PowerShell, registry notes, manual fallback) that quickstart readers haven't installed anything yet so don't need. Another ~25 lines was an inline \`riverctl\` tutorial that duplicates content in the river repo. Separately: Mac users who already installed via the legacy \`install.sh\` flow will clash with the new \`Freenet.app\` (two launchd agents, two data dirs, possible port conflict) with no warning.

## Solution

- **Drop uninstall content from quickstart.** New \`/uninstall/\` page holds the same material organized by install method: macOS DMG, macOS legacy install.sh, Windows, Linux + manual fallback.
- **Drop inline riverctl tutorial.** Link to the riverctl README in freenet/river, which covers install + first-time flow + full command surface (separate PR: freenet/river#TBD).
- **Add \`/uninstall/\` link** from troubleshooting section.
- **Warn Mac \`install.sh\` users** to uninstall the old install first. Styled callout under the Mac download button, blue-tinted left-bar, anchor-links to the exact section of \`/uninstall/\` for the legacy cleanup steps.
- Quickstart drops to ~60 lines: alpha warning, install tabs, River step, short troubleshooting, uninstall link, What's Next.

## Testing

- \`hugo --minify\`: clean build, 108 pages (was 106, +2 for the new /uninstall/ page and feed).
- Rendered /quickstart/ confirmed: install-note callout present, anchor href points to \`/uninstall/#macos-legacy-installsh-install\`.
- Rendered /uninstall/ confirmed: all 4 sections generate correct heading IDs for the deep link.
- No em-dashes in any new content (per global writing-style rule).

Companion PR: freenet/river will update \`cli/README.md\` for the riverctl link.

[AI-assisted - Claude]