### PR TITLE
docs(podcast): add Decentralize Everything Ep 1 and podcast section

### DIFF
--- a/hugo-site/content/_index.md
+++ b/hugo-site/content/_index.md
@@ -76,6 +76,7 @@ decentralized internet infrastructure that matters.
 <div class="secondary-links">
 
 [Video Talks](/about/video-talks/) ·
+[Podcast](/about/podcast/) ·
 [Matrix Chat](https://matrix.to/#/#freenet-locutus:matrix.org) ·
 [GitHub](https://github.com/freenet/freenet-core) ·
 [FAQ](/about/faq/)

--- a/hugo-site/content/about/news/podcast-ep1-trust.md
+++ b/hugo-site/content/about/news/podcast-ep1-trust.md
@@ -1,0 +1,15 @@
++++
+title = "Podcast: Decentralize Everything, Episode 1: How Do You Trust Someone You've Never Met?"
+date = 2026-04-28
+tags = ["video-talk", "podcast", "front-page"]
+aliases = ["/news/podcast-ep1-trust/"]
++++
+
+Episode 1 of the Freenet podcast, "Decentralize Everything." Ian Clarke explores the question of
+how you can trust someone you've never met, and what that means for building decentralized systems.
+
+{{< youtube id="cCQfjw_Q1zk" >}}
+
+### Also available on
+
+- [𝕏](https://x.com/FreenetOrg/status/2049240009174032538)

--- a/hugo-site/content/about/podcast.md
+++ b/hugo-site/content/about/podcast.md
@@ -1,0 +1,11 @@
+---
+title: "Podcast"
+date: 2026-04-28
+aliases:
+  - /podcast/
+---
+
+The Freenet podcast, _Decentralize Everything_, explores the ideas, technology, and people behind
+building a decentralized internet. New episodes weekly.
+
+{{< latest-news tag="podcast" >}}

--- a/hugo-site/content/about/podcast.md
+++ b/hugo-site/content/about/podcast.md
@@ -6,6 +6,6 @@ aliases:
 ---
 
 The Freenet podcast, _Decentralize Everything_, explores the ideas, technology, and people behind
-building a decentralized internet. New episodes weekly.
+building a decentralized internet.
 
 {{< latest-news tag="podcast" >}}

--- a/hugo-site/hugo.toml
+++ b/hugo-site/hugo.toml
@@ -47,15 +47,21 @@ theme = "freenet"
     parent = "About"
 
   [[menu.main]]
+    name = "Podcast"
+    url = "/about/podcast/"
+    weight = 4
+    parent = "About"
+
+  [[menu.main]]
     name = "University"
     url = "/about/university/"
-    weight = 4
+    weight = 5
     parent = "About"
 
   [[menu.main]]
     name = "People"
     url = "/about/people/"
-    weight = 5
+    weight = 6
     parent = "About"
 
   [[menu.main]]


### PR DESCRIPTION
## Summary
- Add Episode 1 of the Freenet podcast (_Decentralize Everything_, "How do you trust someone you've never met?") as a news entry, tagged `video-talk`, `podcast`, and `front-page` so it surfaces on the home page and the existing `/about/video-talks/` listing.
- Add a new `/about/podcast/` landing page driven by `{{< latest-news tag="podcast" >}}` so future episodes have a dedicated home.
- Add a "Podcast" entry to the top nav under About, and to the home page secondary links.

## Why
The user's request was to add the new video "using the same approach as existing videos in freenet/web" and asked separately about creating a new category for the (potentially weekly) podcast. Cross-tagging this first episode with `video-talk` keeps it visible on `/about/video-talks/` and the home page; the new `podcast` tag + landing page gives the series a dedicated home that scales as more episodes ship.

## Review responses

- **Codex flagged the `video-talk` tag** as a misclassification (would put the post on `/about/video-talks/`). Keeping the tag intentionally — the user asked for "same approach as existing videos," and a podcast episode is still a video in form. The dedicated `/about/podcast/` page covers the future-cadence concern.
- **Skeptical reviewer questioned the X status URL** (`2049240009174032538`). The existing `freenet-lives-video-talk.md` post links a 19-digit ID from Feb 2026 (`2020286069292560705`); the new ID is in the plausible range for a late-April 2026 tweet. URL is exactly what the author supplied.
- **Skeptical reviewer noted** the new `front-page` post bumps `freenet-lives-video-talk` (Feb 2026) off the home page top-5. That's normal news rotation.
- **Code-first flagged** "New episodes weekly" as a brittle forward commitment — softened to drop the cadence claim until a regular schedule is established.

## Future consideration
At weekly cadence, the podcast will dominate the home-page news block via the `front-page` tag. Worth deciding policy (e.g., only the debut episode gets `front-page`) before that piles up — not blocking for ep1.

## Test plan
- [x] `hugo` builds cleanly with the new page and nav entries
- [x] `/about/podcast/` lists the new episode via `latest-news`
- [x] Source titles contain no em-dashes
- [x] `public/` is gitignored (no stale artifacts committed)
- [ ] Spot-check rendered nav and home page on Pages after merge

[AI-assisted - Claude]