### PR TITLE
fix(install): read prompt from /dev/tty when stdin is piped

### DIFF
--- a/hugo-site/static/install.sh
+++ b/hugo-site/static/install.sh
@@ -409,11 +409,26 @@ main() {
         print_path_instructions "$install_dir"
     fi
 
-    # Ask about service installation (unless FREENET_NO_SERVICE is set)
+    # Ask about service installation (unless FREENET_NO_SERVICE is set).
+    # When the script is piped via `curl ... | sh`, stdin is the pipe carrying
+    # script bytes, not the terminal, so a plain `read` cannot capture
+    # keystrokes. Read from /dev/tty when stdin isn't a TTY; if no TTY is
+    # available at all (truly non-interactive shell), skip the prompt rather
+    # than failing under `set -eu`. Note: `[ -r /dev/tty ]` is unreliable —
+    # the access check can pass even when the process has no controlling tty
+    # and the subsequent open fails. Probe by actually opening /dev/tty.
     if [ "${FREENET_NO_SERVICE:-0}" != "1" ]; then
         echo ""
-        printf "Would you like to install Freenet as a system service? [y/N] "
-        read -r response
+        response=""
+        if [ -t 0 ]; then
+            printf "Would you like to install Freenet as a system service? [y/N] "
+            read -r response
+        elif { true </dev/tty; } 2>/dev/null; then
+            printf "Would you like to install Freenet as a system service? [y/N] "
+            read -r response </dev/tty
+        else
+            info "Non-interactive shell detected; skipping service installation prompt."
+        fi
         case "$response" in
             [yY]|[yY][eE][sS])
                 info "Installing service..."

--- a/hugo-site/static/install.sh
+++ b/hugo-site/static/install.sh
@@ -9,6 +9,14 @@
 #   FREENET_INSTALL_DIR  - Installation directory (default: ~/.local/bin)
 #   FREENET_NO_SERVICE   - Set to 1 to skip service installation prompt
 #   FREENET_VERSION      - Specific version to install (default: latest)
+#
+# NOTE: A near-identical copy lives at freenet-core/scripts/install.sh.
+# Keep the two in sync. In particular, the service-install prompt
+# (look for "Would you like to install Freenet as a system service")
+# MUST keep its $0 + /dev/tty handling so that `curl | sh` users can
+# answer the prompt - see freenet/web PR #42 / freenet-core PR for
+# context. A previous fix was already lost once via a bulk resync
+# (web PRs #36/#37).
 
 set -eu
 
@@ -410,25 +418,44 @@ main() {
     fi
 
     # Ask about service installation (unless FREENET_NO_SERVICE is set).
-    # When the script is piped via `curl ... | sh`, stdin is the pipe carrying
-    # script bytes, not the terminal, so a plain `read` cannot capture
-    # keystrokes. Read from /dev/tty when stdin isn't a TTY; if no TTY is
-    # available at all (truly non-interactive shell), skip the prompt rather
-    # than failing under `set -eu`. Note: `[ -r /dev/tty ]` is unreliable —
-    # the access check can pass even when the process has no controlling tty
-    # and the subsequent open fails. Probe by actually opening /dev/tty.
+    #
+    # When the script is piped via `curl ... | sh`, sh reads its own script
+    # source from stdin. A plain `read` at this point would consume bytes
+    # of script source instead of capturing the user's answer, so we
+    # redirect from /dev/tty in that case.
+    #
+    # We detect "sh is reading the script from stdin" via $0: when sh runs
+    # a script file, $0 is the script path; when sh reads its source from
+    # stdin, $0 is the shell name itself (e.g. "sh", "bash"). In the
+    # script-file case we read from stdin as before, so existing
+    # automation patterns like `printf 'y\n' | sh install.sh` still work.
+    # The robust way to bypass the prompt in any invocation form is
+    # FREENET_NO_SERVICE=1.
+    #
+    # `{ true </dev/tty; } 2>/dev/null` is used instead of `[ -r /dev/tty ]`:
+    # the access check can succeed even when the process has no
+    # controlling terminal and the subsequent open(2) fails with ENXIO.
+    # Probe by actually opening /dev/tty.
+    #
+    # `read -r response || response=""` keeps EOF (e.g. Ctrl-D, closed
+    # stdin) from aborting the script under `set -eu`.
     if [ "${FREENET_NO_SERVICE:-0}" != "1" ]; then
         echo ""
         response=""
-        if [ -t 0 ]; then
-            printf "Would you like to install Freenet as a system service? [y/N] "
-            read -r response
-        elif { true </dev/tty; } 2>/dev/null; then
-            printf "Would you like to install Freenet as a system service? [y/N] "
-            read -r response </dev/tty
-        else
-            info "Non-interactive shell detected; skipping service installation prompt."
-        fi
+        case "${0##*/}" in
+            sh|bash|dash|ash|busybox|-sh|-bash|-dash|-ash)
+                # Script source is on stdin (`curl | sh` form).
+                if { true </dev/tty; } 2>/dev/null; then
+                    printf "Would you like to install Freenet as a system service? [y/N] "
+                    read -r response </dev/tty || response=""
+                fi
+                ;;
+            *)
+                # Script ran as a file; stdin carries the user's answer.
+                printf "Would you like to install Freenet as a system service? [y/N] "
+                read -r response || response=""
+                ;;
+        esac
         case "$response" in
             [yY]|[yY][eE][sS])
                 info "Installing service..."
@@ -442,6 +469,8 @@ main() {
                 echo ""
                 echo "You can install the service later with:"
                 echo "  freenet service install"
+                echo ""
+                echo "To skip this prompt entirely in scripted installs, set FREENET_NO_SERVICE=1."
                 ;;
         esac
     fi


### PR DESCRIPTION
## Problem

The Linux install script advertised on the quickstart page is invoked via
`curl -fsSL https://freenet.org/install.sh | sh`. When piped, stdin is the
curl output (script bytes), not the user's terminal, so `read -r response`
at the service-install prompt silently consumes nothing and the prompt
ignores keyboard input.

Reported by Ivvor on Matrix:
> @Ian: Freenet linux install script is broken. Streaming curl to sh causes
> it to not process keyboard input when asking if you want the service
> installed.

## Approach

A previous fix (`eff317ae`, Dec 2025) wrote `read -r response < /dev/tty`,
but PRs #36 / #37 ("resync install.sh + uninstall.sh with freenet-core")
overwrote the file with the freenet-core copy and dropped the override.

This change reapplies the fix and hardens it:

- **stdin is a TTY** → `read` directly (covers `sh install.sh`).
- **stdin is piped, /dev/tty openable** → `read < /dev/tty` (covers `curl | sh`).
- **no tty at all** → skip the prompt with an info message rather than
  aborting under `set -eu` (covers CI / `setsid`).

`{ true </dev/tty; } 2>/dev/null` is used instead of `[ -r /dev/tty ]`,
because the `-r` access check can succeed when the process has no
controlling tty and the subsequent open fails with ENXIO.

## Testing

Smoke-tested with a small harness that extracts the prompt block:

- **Case A — `curl | sh` under a real pty (`script -c`)**: stdin is piped,
  /dev/tty present. Script reads `y` from /dev/tty and proceeds with
  service install. ✅
- **Case B — `setsid ... </dev/null` (no controlling tty)**: script prints
  "Non-interactive shell detected; skipping service installation prompt"
  and continues without erroring. ✅
- `sh -n` parses cleanly.

## Follow-up

`freenet-core/scripts/install.sh` carries the identical bug (the two files
are bit-identical). A matching PR will land there next so the next resync
doesn't regress this file again.

[AI-assisted - Claude]