### PR TITLE
docs(apps): add Freenet Mail to example apps list

### DIFF
--- a/hugo-site/content/build/_index.md
+++ b/hugo-site/content/build/_index.md
@@ -43,6 +43,7 @@ This skill guides you through building contracts, delegates, and UI for Freenet 
 - [River](https://github.com/freenet/river) - decentralized group chat app built on Freenet (in
   development)
 - [Delta](https://github.com/freenet/delta) - decentralized publishing app built on Freenet
+- [Mail](https://github.com/freenet/mail) - decentralized email app built on Freenet
 - [freenet-git](https://github.com/freenet/freenet-git) - decentralized Git collaboration on
   Freenet (in development)
 


### PR DESCRIPTION
## Summary

- Mail (https://github.com/freenet/mail) was recently released and is
  hosted on Freenet (facade contract
  \`122f6AR7PyF8d8mhczuNQM4xrLtBf5t8g2iB7PEVT7KC\`).
- Add it to the Example Apps list on \`/build/\` alongside River,
  Delta, and freenet-git so it's discoverable from the docs.

## Test plan

- [x] \`hugo --gc --minify\` builds without errors.
- [ ] Reviewer confirms wording/position in list.