### PR TITLE
docs: soften delegate 'backups and replicas' claim

### DIFF
--- a/hugo-site/content/build/manual/components/delegates.md
+++ b/hugo-site/content/build/manual/components/delegates.md
@@ -79,7 +79,7 @@ Beyond handling messages, delegates can create, read, and modify contracts; crea
 
 A **key manager delegate** stores private keys and signs data on request, possibly prompting the user for permission. An **inbox delegate** monitors an inbox contract, downloads new messages, decrypts them, and stores them privately for UIs to display. A **contacts delegate** stores and retrieves contact information. An **alerts delegate** watches for events (like mentions in a discussion) and notifies the user.
 
-Delegates can also synchronize with identical delegate instances running on other devices the user controls. With an appropriate shared secret, they communicate securely via Freenet and act as backups and replicas of each other.
+Delegates store their state encrypted on the local device. Recent prior values are kept as snapshots so accidental overwrites can be recovered. Cross-device synchronization is not yet implemented — see [issue #3050](https://github.com/freenet/freenet-core/issues/3050) for the planned vault-delegate primitive.
 
 For a real-world example, River's [chat delegate](https://github.com/freenet/river/tree/main/delegates/chat-delegate) stores per-room signing keys and signs messages, invitations, and room configurations on behalf of the UI, without ever exposing the keys.
 


### PR DESCRIPTION
## Problem

The use-cases section of the delegates manual page currently states:

> Delegates can also synchronize with identical delegate instances running on other devices the user controls. With an appropriate shared secret, they communicate securely via Freenet and act as backups and replicas of each other.

This misleads users about durability guarantees. Cross-device synchronization is **not implemented** — PR #4034 added local snapshot history only. The vault-delegate primitive for cross-device sync is tracked in freenet/freenet-core#3050 and is still planned/aspirational.

## Solution

Replace the inaccurate paragraph with an accurate description:

- Delegates store their state encrypted on the local device.
- Recent prior values are kept as snapshots so accidental overwrites can be recovered.
- Cross-device synchronization is not yet implemented, with a link to freenet-core#3050 for the planned vault-delegate primitive.

The replacement matches the existing tone and Hugo markdown style of the page.

## Reference

Tracked in freenet/freenet-core#4037.