### PR TITLE
docs(faq): remove stale cryptocurrency donation reference

### DIFF
--- a/hugo-site/content/about/faq/index.md
+++ b/hugo-site/content/about/faq/index.md
@@ -212,8 +212,8 @@ advocate for unrestricted exchange of intellectual, scientific, literary, social
 creative, human rights, and cultural expressions, free from interference by state, private, or
 special interests.
 
-You can [donate via credit card or cryptocurrency](/donate), or donate through our
-[Ghost Key](/ghostkey/) mechanism to establish a verifiable cryptographic identity.
+You can [donate via credit card](/donate), or donate through our [Ghost Key](/ghostkey/) mechanism
+to establish a verifiable cryptographic identity.
 
 If you are in a position to make a larger contribution or grant please
 {{< email-protect "gro.teneerf@nai" "email Ian" >}} or reach out to him on


### PR DESCRIPTION
## Problem

A user reported on the site that the FAQ says donations can be made "via credit card or cryptocurrency", but:

- the `/donate` page links to a PayPal-only donation button, and
- `/ghostkey/create/` only offers Stripe credit-card processing.

Cryptocurrency donations were discontinued (Coinbase was unworkable for a non-profit), so the FAQ text is out of date.

## Change

Drop "or cryptocurrency" from the financial-support answer in the FAQ. The paragraph is rewrapped for the line-length change; no other content touched.

[AI-assisted - Claude]