### PR TITLE
feat(home): pin Donate to navbar; add 501(c)(3) institutional footer

### DIFF
--- a/hugo-site/hugo.toml
+++ b/hugo-site/hugo.toml
@@ -88,21 +88,16 @@ theme = "freenet"
     parent = "Build"
 
   [[menu.main]]
-    name = "Support"
-    url = "/donate/"
+    identifier = "ghost-keys"
+    name = "Ghost Keys"
+    url = "/ghostkey/"
     weight = 4
 
   [[menu.main]]
-    name = "Ghost Keys"
-    url = "/ghostkey/"
-    weight = 1
-    parent = "Support"
-
-  [[menu.main]]
+    identifier = "donate"
     name = "Donate"
     url = "/donate/"
-    weight = 2
-    parent = "Support"
+    weight = 5
 
 [params]
   stripePublishableKeyTest = "pk_test_51PUf6RCCPv9UL23G0yLdnS51VCStEcnqzd2AftFWiXAOjFOgonYRRBL6F5eKOCrr2yuEHCBDqqYa8H0w7ouRyW6d00awdNMKsf"

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -318,6 +318,47 @@ p.page-end-spacer {
     opacity: 0.8;
 }
 
+/* Donate header button — restrained, persistent, institutional */
+.navbar-item.donate-nav-button {
+    color: var(--color-primary) !important;
+    border: 1.5px solid var(--color-primary);
+    border-radius: 999px;
+    padding: 0.35rem 1.1rem;
+    margin: 0 0.5rem;
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 0.95rem;
+    line-height: 1.2;
+    transition: background-color 0.15s ease, color 0.15s ease;
+    align-self: center;
+}
+
+.navbar-item.donate-nav-button:hover {
+    background-color: var(--color-primary);
+    color: #ffffff !important;
+}
+
+/* Two render points: navbar-end (desktop) and navbar-brand (mobile, next to
+   burger). Show one at a time so the button is always visible. */
+.navbar-item.donate-nav-button-mobile {
+    display: none;
+}
+
+@media screen and (max-width: 1023px) {
+    .navbar-end .navbar-item.donate-nav-button {
+        display: none;
+    }
+
+    .navbar-item.donate-nav-button-mobile {
+        display: inline-flex;
+        align-items: center;
+        margin-left: auto;
+        margin-right: 0.5rem;
+        padding: 0.3rem 0.95rem;
+        font-size: 0.9rem;
+    }
+}
+
 /* Burger menu color and animation */
 .navbar-burger span {
     background-color: #0066CC;
@@ -505,6 +546,17 @@ p.page-end-spacer {
 
     .navbar-item.ghost-key:hover {
         opacity: 0.8;
+    }
+
+    /* Dark mode Donate header button */
+    .navbar-item.donate-nav-button {
+        color: #4da6ff !important;
+        border-color: #4da6ff;
+    }
+
+    .navbar-item.donate-nav-button:hover {
+        background-color: #4da6ff;
+        color: #0a0a0a !important;
     }
 }
 /* Custom button styles */
@@ -821,6 +873,49 @@ picture.app-screenshot img {
 
   .secondary-links a:hover {
     color: #4da6ff;
+  }
+}
+
+/* Institutional statement in footer — quiet, just establishes 501(c)(3) status */
+.footer-institutional {
+  max-width: 720px;
+  margin: 2rem auto 1rem;
+  padding: 0 1rem;
+  text-align: center;
+  font-size: 0.85rem;
+  line-height: 1.55;
+  color: #64748b;
+}
+
+.footer-institutional p {
+  margin: 0;
+}
+
+.footer-institutional a {
+  color: #64748b;
+  text-decoration: underline;
+  text-decoration-color: rgba(100, 116, 139, 0.4);
+  text-underline-offset: 2px;
+}
+
+.footer-institutional a:hover {
+  color: var(--color-primary);
+  text-decoration-color: var(--color-primary);
+}
+
+@media (prefers-color-scheme: dark) {
+  .footer-institutional,
+  .footer-institutional a {
+    color: #94a3b8;
+  }
+
+  .footer-institutional a {
+    text-decoration-color: rgba(148, 163, 184, 0.4);
+  }
+
+  .footer-institutional a:hover {
+    color: #4da6ff;
+    text-decoration-color: #4da6ff;
   }
 }
 

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -334,7 +334,7 @@ p.page-end-spacer {
 }
 
 .navbar-item.donate-nav-button:hover {
-    background-color: var(--color-primary);
+    background-color: var(--color-primary) !important;
     color: #ffffff !important;
 }
 
@@ -555,7 +555,7 @@ p.page-end-spacer {
     }
 
     .navbar-item.donate-nav-button:hover {
-        background-color: #4da6ff;
+        background-color: #4da6ff !important;
         color: #0a0a0a !important;
     }
 }

--- a/hugo-site/themes/freenet/layouts/partials/footer.html
+++ b/hugo-site/themes/freenet/layouts/partials/footer.html
@@ -1,0 +1,23 @@
+<div class="footer-institutional">
+    <p>
+        Founded in 2001, Freenet is a 501(c)(3) nonprofit organization dedicated to the development
+        of open and democratic digital infrastructure. Contributions supporting Freenet's ongoing
+        development can be made directly through
+        <a href="/donate/">freenet.org/donate</a>.
+        For larger philanthropic contributions, institutional partnerships, or grant discussions,
+        please contact <span id="institutional-contact-email"></span>.
+    </p>
+</div>
+<script type="text/javascript">
+(function () {
+    const reversed = "gro.teneerf@nai";
+    const email = reversed.split('').reverse().join('');
+    const el = document.getElementById("institutional-contact-email");
+    if (el) {
+        const a = document.createElement('a');
+        a.href = 'mailto:' + email;
+        a.textContent = email;
+        el.replaceWith(a);
+    }
+})();
+</script>

--- a/hugo-site/themes/freenet/layouts/partials/footer.html
+++ b/hugo-site/themes/freenet/layouts/partials/footer.html
@@ -5,7 +5,7 @@
         development can be made directly through
         <a href="/donate/">freenet.org/donate</a>.
         For larger philanthropic contributions, institutional partnerships, or grant discussions,
-        please contact <span id="institutional-contact-email"></span>.
+        please contact <span id="institutional-contact-email"><noscript>ian at freenet dot org</noscript></span>.
     </p>
 </div>
 <script type="text/javascript">

--- a/hugo-site/themes/freenet/layouts/partials/menu.html
+++ b/hugo-site/themes/freenet/layouts/partials/menu.html
@@ -79,7 +79,7 @@
         </div>
       </div>
     {{- else }}
-      {{- if eq $name "Ghost Key" }}
+      {{- if eq .Identifier "ghost-keys" }}
         {{- $attrs = merge $attrs (dict "class" (printf "%s ghost-key" ($attrs.class | default "navbar-item"))) }}
       {{- end }}
       {{- if eq .Identifier "donate" }}

--- a/hugo-site/themes/freenet/layouts/partials/menu.html
+++ b/hugo-site/themes/freenet/layouts/partials/menu.html
@@ -18,6 +18,7 @@
           <img src="{{ "freenet_logo.svg" | relURL }}" alt="Freenet Logo" class="logo-img" id="freenet-logo">
           <span class="logo-text">Freenet</span>
         </a>
+        <a class="navbar-item donate-nav-button donate-nav-button-mobile" href="/donate/">Donate</a>
         <label for="navbar-toggle" class="navbar-burger" role="button" aria-label="menu" aria-expanded="false">
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
@@ -25,9 +26,23 @@
         </label>
       </div>
       <div id="freenetNavbar" class="navbar-menu">
+        {{- $startEntries := slice }}
+        {{- $endEntries := slice }}
+        {{- range . }}
+          {{- if eq .Identifier "donate" }}
+            {{- $endEntries = $endEntries | append . }}
+          {{- else }}
+            {{- $startEntries = $startEntries | append . }}
+          {{- end }}
+        {{- end }}
         <div class="navbar-start">
-          {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" .) }}
+          {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" $startEntries) }}
         </div>
+        {{- with $endEntries }}
+          <div class="navbar-end">
+            {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" .) }}
+          </div>
+        {{- end }}
       </div>
     </nav>
   {{- end }}
@@ -66,6 +81,9 @@
     {{- else }}
       {{- if eq $name "Ghost Key" }}
         {{- $attrs = merge $attrs (dict "class" (printf "%s ghost-key" ($attrs.class | default "navbar-item"))) }}
+      {{- end }}
+      {{- if eq .Identifier "donate" }}
+        {{- $attrs = merge $attrs (dict "class" (printf "%s donate-nav-button" ($attrs.class | default "navbar-item"))) }}
       {{- end }}
       <a
         {{- range $k, $v := $attrs }}


### PR DESCRIPTION
## Summary

Surfaces donation as an institutional, persistent header element rather than burying it in a nav dropdown. Adds a quiet 501(c)(3) statement in the site footer.

- **Donate button** in the navbar: outlined pill, top-right on desktop, next to the burger on mobile. Visible on every page in both light and dark mode.
- **Menu restructure**: the redundant "Support" dropdown (which contained "Ghost Keys" + a "Donate" that just duplicated the parent URL) is dissolved. Ghost Keys promoted to its own top-level item. New \`identifier = "donate"\` routes the donate entry into a new \`.navbar-end\` section.
- **Institutional footer block**: small centered gray paragraph on every page — "Founded in 2001, Freenet is a 501(c)(3) nonprofit organization...". \`ian@freenet.org\` is obfuscated via the same reversed-JS pattern as the existing \`email-protect\` shortcode (since shortcodes don't work in partials).
- **Hero**: unchanged — "Try Freenet" stays the lone primary CTA. (An earlier iteration paired a secondary "Donate" button next to it; reverted after design discussion in favor of the quieter navbar approach.)

## Why

The donate path was previously two clicks deep behind a "Support" dropdown. That subtly communicates uncertainty/hobby-project energy for what is in fact a 501(c)(3) nonprofit doing infrastructure stewardship. A visible-but-restrained header donate button + an institutional footer signals continuity and seriousness without converting the site into a fundraising funnel.

## Screenshots

Captured at desktop 1440×900, mobile 390×844, light + dark color schemes. Verified via Playwright that the navbar pill is visible without crowding the existing hero, the mobile pill sits next to the burger (not hidden behind it), the footer block reads as institutional boilerplate rather than CTA, and /donate/ still renders correctly.

## Test plan

- [ ] Hugo builds with no errors
- [ ] Donate button visible in navbar on / and on every other page
- [ ] Mobile (≤1023px): Donate pill renders next to burger, navbar-end version hidden
- [ ] Desktop (>1023px): Donate pill in top-right navbar-end, mobile-brand version hidden
- [ ] Dark mode: pill border/text use light-blue tokens; footer text uses muted dark-mode gray
- [ ] Footer 501(c)(3) line renders on /, /donate/, /about/, /build/
- [ ] \`ian@freenet.org\` link is JS-revealed (not in static HTML for scrapers)
- [ ] Ghost Keys top-level link still works (no longer under Support)

[AI-assisted - Claude]