### PR TITLE
feat(nav): restructure top-level menu around audience; add /apps/ ecosystem page

### DIFF
--- a/hugo-site/content/_index.md
+++ b/hugo-site/content/_index.md
@@ -83,8 +83,8 @@ decentralized internet infrastructure that matters.
 
 <div class="secondary-links">
 
+[Apps](/apps/) ·
 [Video Talks](/about/video-talks/) ·
-[Podcast](/about/podcast/) ·
 [Matrix Chat](https://matrix.to/#/#freenet-locutus:matrix.org) ·
 [GitHub](https://github.com/freenet/freenet-core) ·
 [FAQ](/about/faq/)

--- a/hugo-site/content/apps/_index.md
+++ b/hugo-site/content/apps/_index.md
@@ -10,7 +10,7 @@ aliases:
 
 The apps below run on Freenet rather than on a company's servers. They are
 unstoppable, interoperable by default, and built on the same open protocol.
-Everything in Freenet's ecosystem — apps, tools, components — can interoperate
+Everything in Freenet's ecosystem (apps, tools, components) can interoperate
 without coordination, so the line between "an app" and "a building block" is
 deliberately thin.
 
@@ -19,7 +19,7 @@ deliberately thin.
 ### River {#river}
 
 Decentralized group chat. Encrypted rooms that work even if every Freenet
-contributor disappears tomorrow. The fastest way to see Freenet in action — the
+contributor disappears tomorrow. The fastest way to see Freenet in action: the
 [Quickstart](/quickstart/) joins you to the live developers' room.
 
 → [github.com/freenet/river](https://github.com/freenet/river)
@@ -64,7 +64,7 @@ recommendation, and curation systems on top. Early RFC.
 
 ### Raven {#raven}
 
-Decentralized live social feed — posts, profiles, follows, likes — designed as
+Decentralized live social feed (posts, profiles, follows, likes), designed as
 a high-churn live surface that complements [Atlas](#atlas) for durable
 discovery and archival.
 

--- a/hugo-site/content/apps/_index.md
+++ b/hugo-site/content/apps/_index.md
@@ -1,0 +1,94 @@
+---
+title: "Apps & Ecosystem"
+date: 2026-05-23
+draft: false
+layout: "single"
+aliases:
+  - /build/example-apps/
+  - /dev/apps/
+---
+
+The apps below run on Freenet rather than on a company's servers. They are
+unstoppable, interoperable by default, and built on the same open protocol.
+Everything in Freenet's ecosystem — apps, tools, components — can interoperate
+without coordination, so the line between "an app" and "a building block" is
+deliberately thin.
+
+## Available now
+
+### River {#river}
+
+Decentralized group chat. Encrypted rooms that work even if every Freenet
+contributor disappears tomorrow. The fastest way to see Freenet in action — the
+[Quickstart](/quickstart/) joins you to the live developers' room.
+
+→ [github.com/freenet/river](https://github.com/freenet/river)
+
+### Delta {#delta}
+
+Decentralized website builder and publishing platform. Author and publish sites
+that live across the peer-to-peer network with no hosting bills and no
+take-down vector.
+
+→ [github.com/freenet/delta](https://github.com/freenet/delta)
+
+### Mail {#mail}
+
+Decentralized email built on Freenet. Messages routed peer-to-peer with no
+provider in the middle.
+
+→ [github.com/freenet/mail](https://github.com/freenet/mail)
+
+### freenet-git {#freenet-git}
+
+Decentralized Git hosting and collaboration over Freenet. Push and clone
+without depending on a central forge.
+
+→ [github.com/freenet/freenet-git](https://github.com/freenet/freenet-git)
+
+## In development
+
+### Harvest {#harvest}
+
+Decentralized marketplace for peer-to-peer commerce. Anonymous,
+donation-backed identities paired with a blind-signature feedback mechanism
+provide accountability without a central operator. Early design.
+
+### Atlas {#atlas}
+
+Decentralized discovery layer: a framework for publishing signed metadata
+about Freenet content and building competing, pluralistic search,
+recommendation, and curation systems on top. Early RFC.
+
+→ [github.com/freenet/atlas](https://github.com/freenet/atlas)
+
+### Raven {#raven}
+
+Decentralized live social feed — posts, profiles, follows, likes — designed as
+a high-churn live surface that complements [Atlas](#atlas) for durable
+discovery and archival.
+
+→ [github.com/freenet/raven](https://github.com/freenet/raven)
+
+## Tools & components
+
+### Ghost Keys {#ghost-keys}
+
+Anonymous, Sybil-resistant identity certificates. Donate a small amount to
+mint a key; apps can verify the certificate without learning who you are. Used
+across Freenet apps as a spam- and abuse-resistance primitive.
+
+→ [Get a Ghost Key](/ghostkey/) · [github.com/freenet/ghostkeys](https://github.com/freenet/ghostkeys)
+
+### freenet-scaffold {#freenet-scaffold}
+
+A Rust utility crate that simplifies building Freenet contracts with efficient,
+mergeable state synchronization.
+
+→ [github.com/freenet/freenet-scaffold](https://github.com/freenet/freenet-scaffold)
+
+---
+
+Building something new on Freenet? See the [tutorial](/build/manual/tutorial/)
+and [manual](/build/manual/) to get started, or open a PR to add your project
+to this page.

--- a/hugo-site/content/build/_index.md
+++ b/hugo-site/content/build/_index.md
@@ -5,7 +5,6 @@ draft: false
 aliases:
   - /dev/
   - /dev/platform/
-  - /dev/apps/
 ---
 
 ## Getting Started
@@ -36,16 +35,14 @@ This skill guides you through building contracts, delegates, and UI for Freenet 
 
 *   **[ghostkeys](https://github.com/freenet/ghostkeys)**: A Freenet delegate for managing [ghost key](/ghostkey/) identities, enabling trust verification without revealing identity through blind-signed cryptographic certificates.
 
-## Example Apps
+## Example Apps {#example-apps}
 
-- [freenet-ping](https://github.com/freenet/freenet-core/tree/main/apps/freenet-ping) - a simple
-  example demonstrating how to build a Freenet app
-- [River](https://github.com/freenet/river) - decentralized group chat app built on Freenet (in
-  development)
-- [Delta](https://github.com/freenet/delta) - decentralized publishing app built on Freenet
-- [Mail](https://github.com/freenet/mail) - decentralized email app built on Freenet
-- [freenet-git](https://github.com/freenet/freenet-git) - decentralized Git collaboration on
-  Freenet (in development)
+See [Apps & Ecosystem](/apps/) for a current list of applications and components built on Freenet,
+including links to the source code for each project.
+
+A minimal worked example for developers:
+[freenet-ping](https://github.com/freenet/freenet-core/tree/main/apps/freenet-ping) — the smallest
+useful Freenet app, demonstrating the contract / delegate / UI loop end-to-end.
 
 ## Recently Merged Features
 

--- a/hugo-site/content/build/_index.md
+++ b/hugo-site/content/build/_index.md
@@ -41,7 +41,7 @@ See [Apps & Ecosystem](/apps/) for a current list of applications and components
 including links to the source code for each project.
 
 A minimal worked example for developers:
-[freenet-ping](https://github.com/freenet/freenet-core/tree/main/apps/freenet-ping) — the smallest
+[freenet-ping](https://github.com/freenet/freenet-core/tree/main/apps/freenet-ping): the smallest
 useful Freenet app, demonstrating the contract / delegate / UI loop end-to-end.
 
 ## Recently Merged Features

--- a/hugo-site/content/build/manual/_index.md
+++ b/hugo-site/content/build/manual/_index.md
@@ -94,8 +94,8 @@ Additional resources and glossary:
 
 Deep-dive articles on the design principles behind Freenet's architecture:
 
-- [Understanding Small World Networks](/about/news/small-world-networks/) — the routing intuition
-  behind the P2P network: how Freenet finds destinations in just a few hops without a central
+- [Understanding Small World Networks](/about/news/small-world-networks/): the routing intuition
+  behind the P2P network. How Freenet finds destinations in just a few hops without a central
   index.
-- [Understanding Freenet's Delta-Sync](/about/news/summary-delta-sync/) — how shared state stays
+- [Understanding Freenet's Delta-Sync](/about/news/summary-delta-sync/): how shared state stays
   consistent across the network using mergeable, additive updates rather than full snapshots.

--- a/hugo-site/content/build/manual/_index.md
+++ b/hugo-site/content/build/manual/_index.md
@@ -22,6 +22,7 @@ usage. Use the table of contents below to navigate through the manual.
 5. [Examples](#examples)
 6. [Community and Support](#community-and-support)
 7. [Reference](#reference)
+8. [Further reading](#further-reading)
 
 ---
 
@@ -86,3 +87,15 @@ Get involved with the Freenet community:
 Additional resources and glossary:
 
 - [Glossary](glossary)
+
+---
+
+## Further reading {#further-reading}
+
+Deep-dive articles on the design principles behind Freenet's architecture:
+
+- [Understanding Small World Networks](/about/news/small-world-networks/) — the routing intuition
+  behind the P2P network: how Freenet finds destinations in just a few hops without a central
+  index.
+- [Understanding Freenet's Delta-Sync](/about/news/summary-delta-sync/) — how shared state stays
+  consistent across the network using mergeable, additive updates rather than full snapshots.

--- a/hugo-site/hugo.toml
+++ b/hugo-site/hugo.toml
@@ -47,21 +47,9 @@ theme = "freenet"
     parent = "About"
 
   [[menu.main]]
-    name = "YouTube"
-    url = "https://www.youtube.com/@FreenetOrg"
-    weight = 4
-    parent = "About"
-
-  [[menu.main]]
-    name = "University"
-    url = "/about/university/"
-    weight = 5
-    parent = "About"
-
-  [[menu.main]]
     name = "People"
     url = "/about/people/"
-    weight = 6
+    weight = 4
     parent = "About"
 
   [[menu.main]]
@@ -70,28 +58,51 @@ theme = "freenet"
     weight = 3
 
   [[menu.main]]
+    name = "Quickstart"
+    url = "/quickstart/"
+    weight = 1
+    parent = "Build"
+
+  [[menu.main]]
     name = "Tutorial"
     url = "/build/manual/tutorial/"
-    weight = 1
+    weight = 2
     parent = "Build"
 
   [[menu.main]]
     name = "Manual"
     url = "/build/manual/"
-    weight = 2
-    parent = "Build"
-
-  [[menu.main]]
-    name = "Example Apps"
-    url = "/build/#example-apps"
     weight = 3
     parent = "Build"
 
   [[menu.main]]
-    identifier = "ghost-keys"
-    name = "Ghost Keys"
-    url = "/ghostkey/"
+    name = "Apps"
+    url = "/apps/"
     weight = 4
+
+  [[menu.main]]
+    name = "River"
+    url = "/apps/#river"
+    weight = 1
+    parent = "Apps"
+
+  [[menu.main]]
+    name = "Delta"
+    url = "/apps/#delta"
+    weight = 2
+    parent = "Apps"
+
+  [[menu.main]]
+    name = "freenet-git"
+    url = "/apps/#freenet-git"
+    weight = 3
+    parent = "Apps"
+
+  [[menu.main]]
+    name = "All apps & components →"
+    url = "/apps/"
+    weight = 4
+    parent = "Apps"
 
   [[menu.main]]
     identifier = "donate"

--- a/hugo-site/hugo.toml
+++ b/hugo-site/hugo.toml
@@ -93,15 +93,21 @@ theme = "freenet"
     parent = "Apps"
 
   [[menu.main]]
+    name = "Mail"
+    url = "/apps/#mail"
+    weight = 3
+    parent = "Apps"
+
+  [[menu.main]]
     name = "freenet-git"
     url = "/apps/#freenet-git"
-    weight = 3
+    weight = 4
     parent = "Apps"
 
   [[menu.main]]
     name = "All apps & components →"
     url = "/apps/"
-    weight = 4
+    weight = 5
     parent = "Apps"
 
   [[menu.main]]

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -302,22 +302,6 @@ p.page-end-spacer {
     display: inline-block; /* Fit the content width */
 }
 
-/* Ghost Key styling */
-.navbar-item.ghost-key {
-    font-weight: bold;
-    background-color: transparent;
-    border-radius: 4px;
-    background-image: radial-gradient(circle, #339966 0%, #1f5c3d 50%, #000000 100%);
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
-}
-
-.navbar-item.ghost-key:hover {
-    background-color: transparent;
-    opacity: 0.8;
-}
-
 /* Donate header button — restrained, persistent, institutional */
 .navbar-item.donate-nav-button {
     color: var(--color-primary) !important;
@@ -520,14 +504,6 @@ p.page-end-spacer {
         border-bottom-color: #3a3a3a;
     }
 
-    /* Dark mode Ghost Key styling */
-    .navbar-item.ghost-key {
-        background-image: radial-gradient(circle, #4dcc8f 0%, #339966 50%, #E0E0E0 100%);
-        -webkit-background-clip: text;
-        background-clip: text;
-        color: transparent;
-    }
-
     /* Mobile image handling */
     @media screen and (max-width: 800px) {
         div[style*="float: right"] {
@@ -542,10 +518,6 @@ p.page-end-spacer {
         div[style*="float: right"] + p {
             min-width: 200px; /* Ensures at least ~10 words can fit */
         }
-    }
-
-    .navbar-item.ghost-key:hover {
-        opacity: 0.8;
     }
 
     /* Dark mode Donate header button */

--- a/hugo-site/themes/freenet/layouts/partials/menu.html
+++ b/hugo-site/themes/freenet/layouts/partials/menu.html
@@ -79,9 +79,6 @@
         </div>
       </div>
     {{- else }}
-      {{- if eq .Identifier "ghost-keys" }}
-        {{- $attrs = merge $attrs (dict "class" (printf "%s ghost-key" ($attrs.class | default "navbar-item"))) }}
-      {{- end }}
       {{- if eq .Identifier "donate" }}
         {{- $attrs = merge $attrs (dict "class" (printf "%s donate-nav-button" ($attrs.class | default "navbar-item"))) }}
       {{- end }}


### PR DESCRIPTION
## Summary

Reorganizes top-level navigation from content-type-shaped to **audience-shaped**, and adds the missing ecosystem overview page so visitors can see what's actually built on Freenet.

Each top-level item is a one-click door for a visitor intent:

| | | |
|--|--|--|
| **About** | I want to understand the project | FAQ, News, Video Talks, People |
| **Build** | I want to build on it | Quickstart, Tutorial, Manual |
| **Apps** | I want to see what's built on it | River, Delta, freenet-git, All apps & components → |
| **Donate** (pill) | I want to support it | — |

## New: /apps/ page

Single page answering \"what's actually built on Freenet?\". Sections:

- **Available now** — River, Delta, Mail, freenet-git
- **In development** — Harvest, Atlas, Raven
- **Tools & components** — Ghost Keys, freenet-scaffold

Embraces the apps-vs-components blur rather than fighting it (everything in Freenet is interoperable by default, so the page itself is the answer to that distinction).

## Menu changes

| Drop | Rationale |
|------|-----------|
| About > YouTube | The Video Talks page intro already links the channel |
| About > University | Two articles is not a section; surfaced from Manual instead |
| Build > Example Apps | Consolidated into /apps/ |
| Top-level Ghost Keys | Moved into /apps/ under Tools & components |

| Add | Rationale |
|-----|-----------|
| Build > Quickstart | Was only reachable via homepage hero button |
| Top-level Apps | The missing ecosystem door |

## University → Manual

The two \"University\" deep-dive articles (Small World Networks, Delta-Sync) are surfaced from a new \"Further reading\" section at the bottom of the Manual — they're conceptual primers for Architecture topics already covered there. The /about/university/ URL stays live; only the menu entry is gone.

## Redirects (verified locally)

- \`/build/example-apps/\` → \`/apps/\` (new Hugo alias)
- \`/dev/apps/\` → \`/apps/\` (moved from /build/_index.md to /apps/_index.md so it points at the more accurate destination)
- \`/build/#example-apps\` anchor still works (kept the heading with explicit \`{#example-apps}\` ID; content replaced with pointer to /apps/)
- /about/university/, /ghostkey/, and both deep-dive article URLs unchanged

## Pre-existing 404 fix (drive-by)

The homepage secondary-links pointed at \`/about/podcast/\` which has been returning 404 in production (no podcast page exists). Replaced with a link to /apps/.

## Test plan

- [ ] Hugo builds clean
- [ ] All three dropdowns render (About / Build / Apps) on desktop + mobile burger
- [ ] /apps/ renders in light and dark mode
- [ ] Manual's Further reading links resolve to the deep-dive articles
- [ ] /build/example-apps/, /dev/apps/ redirect to /apps/
- [ ] /build/#example-apps still scrolls to the heading
- [ ] /about/university/, /ghostkey/ still work
- [ ] Donate pill still pinned to navbar-end (and next to burger on mobile)
- [ ] 501(c)(3) institutional footer still on every page

Screenshots captured locally at 1440×900 (light + dark) and 390×844 (mobile + burger open). Will share in a reply comment.

[AI-assisted - Claude]