### PR TITLE
docs: link whitepaper alongside tutorial in For Developers section

### DIFF
--- a/hugo-site/content/_index.md
+++ b/hugo-site/content/_index.md
@@ -66,6 +66,8 @@ maintain, no cloud bills, no terms of service.
 
 [Read the Tutorial →](/build/manual/tutorial/)
 
+[Read the Whitepaper →](/whitepaper/)
+
 </div>
 
 <div class="home-section">


### PR DESCRIPTION
## Summary

- Adds a `Read the Whitepaper →` link to the **For Developers** card on the homepage, alongside the existing `Read the Tutorial →` link.
- Both links are equally weighted — the whitepaper is a peer entry point to the tutorial for developers evaluating the platform, not a secondary "learn more" item.
- Pure markdown content addition — no template/CSS changes; renders as a second `<p><a>` paragraph using the same styling as the existing link.

## Test plan

- [x] `hugo` build clean, rendered HTML inspected
- [ ] CI green on this PR before merge

[AI-assisted - Claude]