### PR TITLE
donate: add /donate/thanks/ page and redirect /join to it

### DIFF
--- a/hugo-site/content/donate/thanks/_index.md
+++ b/hugo-site/content/donate/thanks/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Thank you"
+date: 2026-05-25
+aliases:
+  - /join/
+---
+
+## Thank you for supporting Freenet
+
+Your donation helps fund the development of decentralized infrastructure for a
+free and open internet. Freenet is a 501(c)(3) non-profit, and contributions
+are tax-deductible in the United States.
+
+### Stay connected
+
+- Join the conversation on [Matrix](https://matrix.to/#/#freenet:matrix.org)
+- Follow project updates on [our news page](/about/news/)
+- Read about the architecture in the [whitepaper](/whitepaper/)


### PR DESCRIPTION
## Summary

A donor reported their PayPal donation returned them to `freenet.org/join?donated=yes`, which 404s — no `/join` page has existed on the Hugo site for years.

The return URL is stored inside the PayPal hosted button's saved configuration (button_id `EQ9E7DPHB6ETY`), not in our page code (only PayPal reference in the repo is the donate link itself, no `return=` param).

## Changes

- Add `hugo-site/content/donate/thanks/_index.md` — a proper thank-you page for completed donations.
- Use Hugo's `aliases` frontmatter to redirect `/join/` → `/donate/thanks/`, so the existing broken URL works (safety net for cached PayPal receipts and the window before any PayPal-side fix takes effect).

## Follow-up (PayPal side, not in this PR)

Set the account-level **Auto Return URL** in PayPal to `https://freenet.org/donate/thanks/` (under Account Settings → Website Payments / Website Preferences). This overrides the per-button return URL embedded in `EQ9E7DPHB6ETY` so we don't have to hunt for that hosted button in PayPal's UI.

## Test plan

- [x] Local `hugo` build succeeds.
- [x] `public/join/index.html` is generated with a meta-refresh to `/donate/thanks/`.
- [x] `public/donate/thanks/index.html` is generated.
- [ ] After merge, `curl -I https://freenet.org/join` returns 200 with the redirect HTML, and `https://freenet.org/donate/thanks/` renders the page.

[AI-assisted - Claude]