### PR TITLE
fix: use absolute paths for people headshots

### DIFF
--- a/hugo-site/content/about/people/ian-clarke/index.md
+++ b/hugo-site/content/about/people/ian-clarke/index.md
@@ -6,7 +6,7 @@ aliases:
   - /people/ian-clarke/
 ---
 
-<img src="ian-clarke.jpg" alt="Ian Clarke" style="float: right; width: 220px; margin: 0 0 20px 20px; border-radius: 4px;">
+<img src="/about/people/ian-clarke/ian-clarke.jpg" alt="Ian Clarke" style="float: right; width: 220px; margin: 0 0 20px 20px; border-radius: 4px;">
 
 Ian Clarke is a computer scientist and entrepreneur, best known as the creator of
 [Freenet](https://freenet.org), a decentralized peer-to-peer platform for censorship-resistant

--- a/hugo-site/content/about/people/steven-starr/index.md
+++ b/hugo-site/content/about/people/steven-starr/index.md
@@ -6,7 +6,7 @@ aliases:
   - /people/steven-starr/
 ---
 
-<img src="steven-starr.jpeg" alt="Steven Starr" style="float: right; width: 220px; margin: 0 0 20px 20px; border-radius: 4px;">
+<img src="/about/people/steven-starr/steven-starr.jpeg" alt="Steven Starr" style="float: right; width: 220px; margin: 0 0 20px 20px; border-radius: 4px;">
 
 Steven Starr is a media entrepreneur, filmmaker, civic activist, and longtime advocate for
 decentralization and digital autonomy. He is co-founder of The Freenet Project, a nonprofit


### PR DESCRIPTION
The listing page at \`/about/people/\` renders each child's Summary, which included the raw \`<img src="steven-starr.jpeg">\`. On the listing page that resolved to \`/about/people/steven-starr.jpeg\` (404). Use absolute paths so the same HTML works in both the listing and the bio page.

[AI-assisted - Claude]