### PR TITLE
fix: stack people headshots above bio on mobile

### DIFF
--- a/hugo-site/content/about/people/ian-clarke/index.md
+++ b/hugo-site/content/about/people/ian-clarke/index.md
@@ -6,7 +6,7 @@ aliases:
   - /people/ian-clarke/
 ---
 
-<img src="/about/people/ian-clarke/ian-clarke.jpg" alt="Ian Clarke" style="float: right; width: 220px; margin: 0 0 20px 20px; border-radius: 4px;">
+<img src="/about/people/ian-clarke/ian-clarke.jpg" alt="Ian Clarke" class="person-headshot">
 
 Ian Clarke is a computer scientist and entrepreneur, best known as the creator of
 [Freenet](https://freenet.org), a decentralized peer-to-peer platform for censorship-resistant

--- a/hugo-site/content/about/people/steven-starr/index.md
+++ b/hugo-site/content/about/people/steven-starr/index.md
@@ -6,7 +6,7 @@ aliases:
   - /people/steven-starr/
 ---
 
-<img src="/about/people/steven-starr/steven-starr.jpeg" alt="Steven Starr" style="float: right; width: 220px; margin: 0 0 20px 20px; border-radius: 4px;">
+<img src="/about/people/steven-starr/steven-starr.jpeg" alt="Steven Starr" class="person-headshot">
 
 Steven Starr is a media entrepreneur, filmmaker, civic activist, and longtime advocate for
 decentralization and digital autonomy. He is co-founder of The Freenet Project, a nonprofit

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -1210,3 +1210,19 @@ picture.app-screenshot img {
     --bulma-code-background: #1e2430;
   }
 }
+
+.person-headshot {
+  float: right;
+  width: 220px;
+  margin: 0 0 20px 20px;
+  border-radius: 4px;
+}
+@media screen and (max-width: 600px) {
+  .person-headshot {
+    float: none;
+    display: block;
+    width: 100%;
+    max-width: 260px;
+    margin: 0 auto 16px;
+  }
+}


### PR DESCRIPTION
A 220px \`float: right\` image leaves only a sliver of width on phones, so each line wrapped after one or two words and the rest of the paragraph fell below the image.

Move the inline styles to a \`.person-headshot\` class with a \`max-width: 600px\` media query that drops the float and centers the image above the paragraph on narrow screens.

[AI-assisted - Claude]