### PR TITLE
fix: render people headshots at consistent 220x220 with float clear

### DIFF
--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -1213,16 +1213,21 @@ picture.app-screenshot img {
 
 .person-headshot {
   float: right;
+  clear: right;
   width: 220px;
+  height: 220px;
+  object-fit: cover;
+  object-position: center 20%;
   margin: 0 0 20px 20px;
   border-radius: 4px;
 }
 @media screen and (max-width: 600px) {
   .person-headshot {
     float: none;
+    clear: none;
     display: block;
-    width: 100%;
-    max-width: 260px;
+    width: 220px;
+    height: 220px;
     margin: 0 auto 16px;
   }
 }


### PR DESCRIPTION
Two issues on \`/about/people/\` after #54:

1. **Inconsistent sizes** — the rule only set \`width\`, so Steven's 800×1011 source rendered 220×278 (portrait) while Ian's 800×800 source rendered 220×220 (square).
2. **No float clear** — on the listing page Ian's right-floated image floated up beside Steven's bio because no element cleared the prior float.

Fix: pin a 220×220 square frame on \`.person-headshot\` and use \`object-fit: cover; object-position: center 20%\` so both faces stay in frame. Add \`clear: right\` so each new headshot starts below the previous. Mobile rule keeps the same 220×220 centered above the bio.

Verified at 375 / 600 / 768 / 1024 / 1280 / 1600 px on a local Hugo build.

[AI-assisted - Claude]