### PR TITLE
fix: contain headshot floats per-bio with .child-entry wrapper

### DIFF
--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -1211,23 +1211,26 @@ picture.app-screenshot img {
   }
 }
 
+.child-entry {
+  display: flow-root;
+  margin-bottom: 1.5rem;
+}
+
 .person-headshot {
   float: right;
-  clear: right;
-  width: 220px;
-  height: 220px;
+  width: 160px;
+  height: 160px;
   object-fit: cover;
   object-position: center 20%;
-  margin: 0 0 20px 20px;
+  margin: 0 0 12px 20px;
   border-radius: 4px;
 }
 @media screen and (max-width: 600px) {
   .person-headshot {
     float: none;
-    clear: none;
     display: block;
-    width: 220px;
-    height: 220px;
+    width: 180px;
+    height: 180px;
     margin: 0 auto 16px;
   }
 }

--- a/hugo-site/themes/freenet/layouts/_default/list.html
+++ b/hugo-site/themes/freenet/layouts/_default/list.html
@@ -8,15 +8,17 @@
         </div>
         <div>
           {{ range .Pages }}
-              <h2 class="title is-5">
-                <a href="{{ .RelPermalink }}" style="color: #444444;">{{ .LinkTitle }}</a>
-              </h2>
-              {{ if eq .Section "news" }}
-                <p class="date">{{ .Date.Format "2 January, 2006" }}</p>
-              {{ end }}
-              <div class="content">
-                {{ .Summary }}
-              </div>
+              <section class="child-entry">
+                <h2 class="title is-5">
+                  <a href="{{ .RelPermalink }}" style="color: #444444;">{{ .LinkTitle }}</a>
+                </h2>
+                {{ if eq .Section "news" }}
+                  <p class="date">{{ .Date.Format "2 January, 2006" }}</p>
+                {{ end }}
+                <div class="content">
+                  {{ .Summary }}
+                </div>
+              </section>
           {{ end }}
         </div>
       {{ else }}


### PR DESCRIPTION
After #55, Ian's headshot on \`/about/people/\` ended up next to the footer rather than beside his bio. Root cause: the listing template emits each child's \`<h2>\` and \`<div class="content">\` as bare siblings, so Steven's tall float-right photo extended past his own short paragraph; Ian's image with \`clear: right\` then floated past the entire content area into the footer's row.

Fix:
- Wrap each child page in \`<section class="child-entry">\` in \`_default/list.html\` (the template actually used for section pages — \`single.html\` was a red herring from an earlier debug pass).
- Set \`.child-entry { display: flow-root }\` so each bio's float is contained.
- Shrink the headshot to 160×160 (180×180 on mobile) so it fits comfortably beside short summary text.

Verified at 375 / 600 / 768 / 1024 / 1280 / 1600 px on a local Hugo build — at every desktop width both images now align to the same right edge, each beside its own bio.

[AI-assisted - Claude]