### PR TITLE
docs: order Ian Clarke above Steven Starr on people page

### DIFF
--- a/hugo-site/content/about/people/ian-clarke/index.md
+++ b/hugo-site/content/about/people/ian-clarke/index.md
@@ -2,6 +2,7 @@
 title: "Ian Clarke"
 date: 2026-04-03
 draft: false
+weight: 1
 aliases:
   - /people/ian-clarke/
 ---

--- a/hugo-site/content/about/people/steven-starr/index.md
+++ b/hugo-site/content/about/people/steven-starr/index.md
@@ -2,6 +2,7 @@
 title: "Steven Starr"
 date: 2026-05-27
 draft: false
+weight: 2
 aliases:
   - /people/steven-starr/
 ---


### PR DESCRIPTION
Pin the listing order with explicit \`weight\` front matter — Ian (founder) gets weight 1, Steven weight 2 — so the ordering doesn't silently shift as more people are added or dates change.

[AI-assisted - Claude]