### PR TITLE
fix: use localhost instead of 127.0.0.1 in local-node browser links

### DIFF
--- a/hugo-site/static/js/donation-success.js
+++ b/hugo-site/static/js/donation-success.js
@@ -281,7 +281,10 @@ function displayCertificate(armoredCertificate, armoredSigningKey) {
         const certB64 = urlSafeBase64(armoredCertificate);
         const skB64 = urlSafeBase64(armoredSigningKey);
         const contractId = 'DLog47hEsrtuGT4N5XCeMBG45m4n1aWM89tBZXue2E1N';
-        const importUrl = `http://127.0.0.1:7509/v1/contract/web/${contractId}/#import=${certB64}.${skB64}`;
+        // Use localhost rather than the literal 127.0.0.1: the node binds its
+        // API on the IPv6 loopback by default, so on Windows "localhost" (::1)
+        // is reachable while the literal IPv4 address is refused.
+        const importUrl = `http://localhost:7509/v1/contract/web/${contractId}/#import=${certB64}.${skB64}`;
         window.open(importUrl, '_blank');
       });
     }

--- a/hugo-site/themes/freenet/layouts/shortcodes/river-invite-button.html
+++ b/hugo-site/themes/freenet/layouts/shortcodes/river-invite-button.html
@@ -156,7 +156,11 @@
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const apiUrl = window.ghostkeyApiUrl;
-    const riverBaseUrl = 'http://127.0.0.1:7509/v1/contract/web/raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv/';
+    // Use localhost rather than the literal 127.0.0.1 so the link works on
+    // Windows: the node binds its API on the IPv6 loopback by default, and
+    // Windows resolves "localhost" to ::1 (reachable) while the literal IPv4
+    // address is refused. localhost is reachable on every platform.
+    const riverBaseUrl = 'http://localhost:7509/v1/contract/web/raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv/';
 
     const getInviteBtn = document.getElementById('get-invite-btn');
     const inviteForm = document.getElementById('invite-form');


### PR DESCRIPTION
## Problem

The **"Open River & Join Chat"** invite button (`river-invite-button.html`) and the Ghost Key **"Import to Freenet"** button (`donation-success.js`) hand the browser a literal `http://127.0.0.1:7509/` URL pointing at the user's local Freenet node.

On **Windows**, opening this URL fails with *"can't access this site."* Replacing `127.0.0.1` with `localhost` makes it work. This was reported in [gigazine.net's River writeup](https://gigazine.net/news/20260531-freenet-river/), where the author had to hand-edit `127.0.0.1` → `localhost` to reach the official chat room.

## Root cause

Since the dual-stack change (freenet-core #3648), the node binds its local HTTP/WS API on the **IPv6 loopback** by default (`::1` in local mode, `::` in network mode) with `IPV6_V6ONLY=false`.

- On **Linux**, the dual-stack socket also accepts IPv4-mapped connections, so `127.0.0.1` works.
- On **Windows**, that path is unreliable and the socket is effectively IPv6-only for inbound, so the literal IPv4 address is refused — while `localhost` (which Windows resolves to `::1`) connects.

## Approach

Use `localhost` rather than the literal `127.0.0.1` for the two browser-facing links. `localhost` is correct on every platform: the browser resolves it to whichever loopback the node is actually listening on. River's UI derives its WebSocket URL from `window.location.host` (`ui/src/components/app/freenet_api/constants.rs`), so loading the page from `localhost:7509` makes the follow-on WS connection use `localhost` too — the fix propagates without any River change.

## Scope / not changed

- **`publish-a-website.md`** shows literal `fdev` terminal output (`Website URL: http://127.0.0.1:7509/...`) and documents `fdev`'s default connection. Changing the docs would misrepresent what the tool prints — the proper fix is in `fdev`/freenet-core.
- **`install.sh`** dashboard message is the Unix `curl | sh` installer (Windows users don't run it; `127.0.0.1` works on Linux).
- **`remote-access.md`** `127.0.0.1` references are SSH-tunnel/config context and correct as-is.
- **Deeper fix (separate, freenet-core):** binding the loopback API dual-stack (both `127.0.0.1` and `::1`) — or reverting the loopback default to IPv4 on Windows — would make the literal IPv4 address work again. Tracked separately; this PR resolves the user-visible symptom for the website's links.

## Testing

- `node --check` passes on `donation-success.js`.
- Verified River's WS URL is host-relative, so `localhost` propagates to the WebSocket connection.
- Prettier warnings on both files are pre-existing (present on `main`) and not gated by CI; left untouched to keep the diff minimal.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)