### PR TITLE
feat(river): dedicated /river landing page

### DIFF
--- a/hugo-site/content/apps/_index.md
+++ b/hugo-site/content/apps/_index.md
@@ -24,7 +24,7 @@ contributor disappears tomorrow. The fastest way to see Freenet in action: the
 
 {{< app-screenshot light="/images/apps/river.png" alt="River decentralized group chat interface" >}}
 
-→ [github.com/freenet/river](https://github.com/freenet/river)
+→ [Visit the River page](/river/) · [github.com/freenet/river](https://github.com/freenet/river)
 
 ### Delta {#delta}
 

--- a/hugo-site/content/river/_index.md
+++ b/hugo-site/content/river/_index.md
@@ -1,0 +1,8 @@
+---
+title: "River: group chat with no servers"
+description: "River is encrypted group chat that runs on Freenet, a global peer-to-peer network, instead of anyone's servers. No company, no account, no phone number."
+date: 2026-07-03
+draft: false
+aliases:
+  - /apps/river/
+---

--- a/hugo-site/hugo.toml
+++ b/hugo-site/hugo.toml
@@ -88,7 +88,7 @@ theme = "freenet"
 
   [[menu.main]]
     name = "River"
-    url = "/apps/#river"
+    url = "/river/"
     weight = 1
     parent = "Apps"
 

--- a/hugo-site/static/images/river_logo.svg
+++ b/hugo-site/static/images/river_logo.svg
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 360 360">
+  <!-- Generator: Adobe Illustrator 29.4.0, SVG Export Plug-In . SVG Version: 2.1.0 Build 152)  -->
+  <defs>
+    <style>
+      .st0 {
+        fill: url(#linear-gradient2);
+      }
+
+      .st1 {
+        fill: url(#linear-gradient1);
+      }
+
+      .st2 {
+        fill: url(#linear-gradient9);
+      }
+
+      .st3 {
+        fill: url(#linear-gradient3);
+      }
+
+      .st4 {
+        fill: url(#linear-gradient6);
+      }
+
+      .st5 {
+        fill: url(#linear-gradient8);
+      }
+
+      .st6 {
+        fill: url(#linear-gradient7);
+      }
+
+      .st7 {
+        fill: url(#linear-gradient5);
+      }
+
+      .st8 {
+        fill: url(#linear-gradient4);
+      }
+
+      .st9 {
+        fill: url(#linear-gradient13);
+      }
+
+      .st10 {
+        fill: url(#linear-gradient12);
+      }
+
+      .st11 {
+        fill: url(#linear-gradient11);
+      }
+
+      .st12 {
+        fill: url(#linear-gradient10);
+      }
+
+      .st13 {
+        fill: url(#linear-gradient);
+      }
+    </style>
+    <linearGradient id="linear-gradient" x1="12.5" y1="-2650.1" x2="3.2" y2="-2754.6" gradientTransform="translate(24.3 -2428.8) rotate(-5.1) scale(1 -1)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#182c8d"/>
+      <stop offset=".6" stop-color="#2860f3"/>
+      <stop offset="1" stop-color="#2962f6"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient1" x1="190.6" y1="466.4" x2="190.6" y2="520.5" gradientTransform="translate(0 -430)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#5fe1ff"/>
+      <stop offset=".6" stop-color="#0275ff"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient2" x1="79.6" y1="-2308.2" x2="276" y2="-2379.6" gradientTransform="translate(0 -2210) scale(1 -1)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#92e0fc"/>
+      <stop offset=".6" stop-color="#49a0f8"/>
+      <stop offset="1" stop-color="#2962f6"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient3" x1="59.6" y1="-2368.4" x2="260.2" y2="-2368.4" gradientTransform="translate(0 -2210) scale(1 -1)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#b4f4ff"/>
+      <stop offset=".3" stop-color="#50c4fa"/>
+      <stop offset=".9" stop-color="#2962f6"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient4" x1="151.6" y1="-2427" x2="127.6" y2="-2361.1" gradientTransform="translate(0 -2210) scale(1 -1)" gradientUnits="userSpaceOnUse">
+      <stop offset=".2" stop-color="#5fccfa"/>
+      <stop offset=".6" stop-color="#2a64f6"/>
+      <stop offset="1" stop-color="#1f3993"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient5" x1="59.7" y1="-2381.3" x2="252" y2="-2381.3" gradientTransform="translate(0 -2210) scale(1 -1)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#b4f4ff"/>
+      <stop offset=".2" stop-color="#50c4fa"/>
+      <stop offset=".7" stop-color="#2962f6"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient6" x1="122" y1="-2392.1" x2="251.6" y2="-2392.1" gradientTransform="translate(0 -2210) scale(1 -1)" gradientUnits="userSpaceOnUse">
+      <stop offset=".3" stop-color="#2951db"/>
+      <stop offset=".7" stop-color="#2959e8"/>
+      <stop offset="1" stop-color="#2962f6"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient7" x1="72.4" y1="-2380.6" x2="104.1" y2="-2325.6" gradientTransform="translate(0 -2210) scale(1 -1)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fff"/>
+      <stop offset="0" stop-color="#f0fafe"/>
+      <stop offset="1" stop-color="#50c4fa"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient8" x1="247.2" y1="-2380.9" x2="267.6" y2="-2437" gradientTransform="translate(0 -2210) scale(1 -1)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2962f6" stop-opacity="0"/>
+      <stop offset="0" stop-color="#275dee" stop-opacity=".1"/>
+      <stop offset=".6" stop-color="#1d3aaf"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient9" x1="94.1" y1="-2334" x2="112.5" y2="-2334" gradientTransform="translate(0 -2210) scale(1 -1)" gradientUnits="userSpaceOnUse">
+      <stop offset=".2" stop-color="#164d8a"/>
+      <stop offset="1" stop-color="#182c8d"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient10" x1="205.6" y1="-2503.1" x2="205.6" y2="-2409.4" gradientTransform="translate(0 -2210) scale(1 -1)" gradientUnits="userSpaceOnUse">
+      <stop offset=".3" stop-color="#2962f6"/>
+      <stop offset=".3" stop-color="#285ff0"/>
+      <stop offset=".9" stop-color="#182c8d"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient11" x1="538.9" y1="-1925.9" x2="618.8" y2="-1955" gradientTransform="translate(-90.5 -1837.8) rotate(8.8) scale(1 -1)" gradientUnits="userSpaceOnUse">
+      <stop offset=".1" stop-color="#5fccfa"/>
+      <stop offset=".5" stop-color="#3d8af7"/>
+      <stop offset="1" stop-color="#1f3993"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient12" x1="204.1" y1="-2409.4" x2="204.1" y2="-2503.1" gradientTransform="translate(0 -2210) scale(1 -1)" gradientUnits="userSpaceOnUse">
+      <stop offset=".2" stop-color="#5fccfa"/>
+      <stop offset=".4" stop-color="#4aa4f8"/>
+      <stop offset=".8" stop-color="#2962f6"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient13" x1="16.4" y1="-2649.3" x2="16.4" y2="-2756.2" gradientTransform="translate(24.3 -2428.8) rotate(-5.1) scale(1 -1)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#5fccfa"/>
+      <stop offset=".7" stop-color="#3274f6"/>
+      <stop offset=".8" stop-color="#2962f6"/>
+    </linearGradient>
+  </defs>
+  <g id="Layer_11" data-name="Layer_1">
+    <g id="Layer_1-2">
+      <path class="st13" d="M261.8,209.7s2.6,7.1,13.2,14.5c10.7,7.4,23.8,21.1,25.7,42.1,1.9,20.9-10.8,48.3-10.8,48.3,0,0,2.3-19.4-12.1-26s-28.3-17.6-32.5-32.4c-7.6-26.9,16.5-46.4,16.5-46.4h0Z"/>
+      <g id="cfZ4UG">
+        <path class="st1" d="M151.4,79.6c2-2.3,3.6-5.2,5.5-7.7,17.2-23,43.1-38.9,72.7-34.8.5.6.1.5,0,.8-1.7,2.6-4.2,5.3-6,8-8.7,13-15.1,29.2-8.4,44.7"/>
+      </g>
+      <path class="st0" d="M59.8,160.4s-3.6-3.4.7-7c4.4-3.6,10.7-9.5,11.2-14.6,6.1-73.6,71.8-82.8,93.4-81.8,75.5,3.6,111.7,73.5,104.6,121.1-6.3,42.4-25.5,57.8-25.5,57.8,0,0,8.7-29.4-15.1-54.1-49.8-51.9-127.4-21.4-146.9-13.8-7.9,3.1-14.1,2.2-16.8,0s-5.8-7.5-5.8-7.5h.2,0Z"/>
+      <path class="st3" d="M59.8,160.4s6.7,2.9,15.3-2.2c24.5-14.6,13.7-77.3,87.5-77.3s113.1,74.3,91.8,136.8c-2.7,7.9-10.2,18.2-10.2,18.2,0,0,8.7-29.4-15.1-54.1-49.8-51.9-127.4-21.4-146.9-13.8-7.9,3.1-14.1,2.2-16.8,0s-5.8-7.5-5.8-7.5h.2,0Z"/>
+      <path class="st8" d="M154.7,151.8l6.1,19.1s-15.5,7.8-20.8,23.6-3.6,27.5-3.6,27.5c0,0-36.6-22.4-13.5-68.1,0,0,2.5-.9,17.2-1.8,8.4-.5,14.7-.3,14.7-.3h0Z"/>
+      <path class="st7" d="M59.8,160.4s6.7,2.9,15.3-2.2c24.5-14.6,47.1-50.9,89.2-51.4,64.1-.8,93.7,56.3,86.7,106.6-1.1,8.3-6.7,22.5-6.7,22.5,0,0,8.7-29.4-15.1-54.1-49.8-51.9-127.4-21.4-146.9-13.8-7.9,3.1-14.1,2.2-16.8,0s-5.8-7.5-5.8-7.5h.1Z"/>
+      <path class="st4" d="M122,155.7s13.2-27.4,52.4-27.4,83.6,34.7,76.6,85.1c-1.1,8.3-6.7,22.5-6.7,22.5,0,0,11.2-32.1-15.1-54.1-46.4-39-107.2-26-107.2-26h0Z"/>
+      <path class="st6" d="M117.8,123.6s-5,3.5-13.2,10.7c-4.1,3.6-19.6,18.3-29.4,23.9-8.7,4.9-15.3,2.2-15.3,2.2,0,0,.9,2.9,3.6,5.1,0,0,8.4,4,20.1-7.9,27.1-27.5,34.3-33.9,34.3-33.9h-.1Z"/>
+      <path class="st5" d="M270.5,164.8c.5,40.8-18.9,63.7-23.9,68.9-.8.8-1.6,1.5-1.6,1.5,0,0,11-24.6-18.6-56.7"/>
+      <path class="st2" d="M94.3,131.7s-1.5-9.1,4.8-13.4c6.3-4.4,13.4-.4,13.4-.4,0,0,.2,7.3-3.4,10.2-3.9,3.2-8.6,3.3-10.7,2.9-2.9-.5-4.1.7-4.1.7h0Z"/>
+      <path class="st12" d="M241.1,199.4s-6.3,7-24.2,11c-60.6,13.7-52.5,82.7-52.5,82.7,0,0,2.4-16.2,15.1-22.9s33.3-7.1,47.1-14.5c35.4-19.1,14.5-56.3,14.5-56.3h0Z"/>
+      <path class="st11" d="M153.2,136.4s-11.7,38.2,25.7,58.1c18.5,9.9,34.5,8.8,34.5,8.8,0,0-8.3-14.4-10.3-26-2.4-14.4-8.1-37.2-26.5-41.7-16.3-3.9-23.4.7-23.4.7h0Z"/>
+      <path class="st10" d="M241,199.4s-6.3,7-24.2,11c-60.6,13.7-52.5,82.7-52.5,82.7,0,0,8.8-29.4,19.4-39.1,18.2-16.6,39.4-16.6,51.9-26,15.6-11.7,5.4-28.7,5.4-28.7h0Z"/>
+      <path class="st9" d="M261.8,209.8s2.6,7.1,13.2,14.5c10.7,7.4,23.8,21.1,25.7,42.1,1.9,20.9-10.8,48.3-10.8,48.3,0,0,4.8-33.4-14.6-51.5-26.8-25.1-13.5-53.3-13.5-53.3h0Z"/>
+    </g>
+  </g>
+</svg>

--- a/hugo-site/themes/freenet/layouts/partials/inline/rv-check.html
+++ b/hugo-site/themes/freenet/layouts/partials/inline/rv-check.html
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>

--- a/hugo-site/themes/freenet/layouts/river/baseof.html
+++ b/hugo-site/themes/freenet/layouts/river/baseof.html
@@ -45,11 +45,11 @@
 
     .rv-btn{ display:inline-flex; align-items:center; gap:.5rem; font-family:var(--font-display); font-weight:600; font-size:1.02rem; padding:.85rem 1.6rem; border-radius:10px; border:1.5px solid transparent; cursor:pointer; transition:transform .15s ease, box-shadow .15s ease, background .15s ease; text-decoration:none; }
     .rv-btn:hover{ transform:translateY(-1px); }
-    .rv-btn-invite{ background:#0b6e33; color:#fff!important; box-shadow:0 4px 14px rgba(11,110,51,.28); }
-    .rv-btn-invite:hover{ background:#095a2a; color:#fff!important; }
+    .rv-btn-primary{ background:#0b6e33; color:#fff!important; box-shadow:0 4px 14px rgba(11,110,51,.28); }
+    .rv-btn-primary:hover{ background:#095a2a; color:#fff!important; }
     @media (prefers-color-scheme: dark){
-      .rv-btn-invite{ background:#34d17f; color:#06251a!important; box-shadow:0 4px 14px rgba(0,0,0,.4); }
-      .rv-btn-invite:hover{ background:#28b86c; color:#06251a!important; }
+      .rv-btn-primary{ background:#34d17f; color:#06251a!important; box-shadow:0 4px 14px rgba(0,0,0,.4); }
+      .rv-btn-primary:hover{ background:#28b86c; color:#06251a!important; }
     }
     .rv-btn-ghost{ border-color:var(--rv-line); color:var(--rv-ink)!important; background:var(--rv-card); }
 

--- a/hugo-site/themes/freenet/layouts/river/baseof.html
+++ b/hugo-site/themes/freenet/layouts/river/baseof.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="{{ or site.Language.LanguageCode site.Language.Lang }}"
+      dir="{{ or site.Language.LanguageDirection `ltr` }}">
+<head>
+    {{ partial "head.html" . }}
+    <style>
+    /* ===== River landing page (scoped to .river-page; loads only on /river) ===== */
+    .river-page{
+      --rv-brand:#0066CC; --rv-brand-deep:#004C99; --rv-brand-bright:#00a6ff;
+      --rv-invite:#16a34a; --rv-invite-deep:#12833f;
+      --rv-band:#eef4fb; --rv-card:#ffffff;
+      --rv-ink:#0f1b2d; --rv-ink-soft:#48586b; --rv-ink-faint:#6b7a8d;
+      --rv-line:rgba(15,27,45,.09); --rv-brand-soft:rgba(0,102,204,.09);
+      --rv-shadow:0 10px 34px rgba(15,40,80,.10); --rv-shadow-l:0 22px 60px rgba(15,40,80,.16);
+    }
+    @media (prefers-color-scheme: dark){
+      .river-page{
+        --rv-band:#171b22; --rv-card:#1e222b;
+        --rv-ink:#f2f5f8; --rv-ink-soft:#aebccb; --rv-ink-faint:#8595a6;
+        --rv-line:rgba(255,255,255,.09); --rv-brand:#4da6ff; --rv-brand-bright:#5cc0ff;
+        --rv-brand-soft:rgba(77,166,255,.12); --rv-invite:#34d17f;
+        --rv-shadow:0 10px 34px rgba(0,0,0,.45); --rv-shadow-l:0 22px 60px rgba(0,0,0,.55);
+      }
+    }
+
+    .rv-wrap{ max-width:1080px; margin:0 auto; padding:0 22px; }
+    .rv-section{ padding:4rem 0; }
+    .rv-band{ padding:4rem 0; background:var(--rv-band); border-top:1px solid var(--rv-line); border-bottom:1px solid var(--rv-line); }
+    .rv-eyebrow{ font-family:var(--font-display); font-weight:600; font-size:.8rem; letter-spacing:.13em; text-transform:uppercase; color:var(--rv-brand); margin:0 0 .9rem; }
+    .rv-h1{ font-size:clamp(2.4rem,5vw,3.5rem); font-weight:700; line-height:1.06; margin:0; letter-spacing:-.02em; text-wrap:balance; }
+    .rv-grad{ background:linear-gradient(115deg,var(--rv-brand-deep),var(--rv-brand) 45%,var(--rv-brand-bright)); -webkit-background-clip:text; background-clip:text; -webkit-text-fill-color:transparent; }
+    @media (prefers-color-scheme: dark){ .rv-grad{ background:linear-gradient(135deg,#4da6ff,#0066CC 50%,#00a6ff); -webkit-background-clip:text; background-clip:text; -webkit-text-fill-color:transparent; } }
+    .rv-h2{ font-size:clamp(1.7rem,3.4vw,2.3rem); font-weight:700; margin:0; text-wrap:balance; }
+    .rv-head{ max-width:44ch; margin-bottom:2.4rem; }
+    .rv-head-sub{ color:var(--rv-ink-soft); margin:.8rem 0 0; }
+    .rv-center{ text-align:center; margin-left:auto; margin-right:auto; }
+
+    .rv-btn{ display:inline-flex; align-items:center; gap:.5rem; font-family:var(--font-display); font-weight:600; font-size:1.02rem; padding:.85rem 1.6rem; border-radius:10px; border:1.5px solid transparent; cursor:pointer; transition:transform .15s ease, box-shadow .15s ease; text-decoration:none; }
+    .rv-btn:hover{ transform:translateY(-1px); }
+    .rv-btn-invite{ background:linear-gradient(135deg,var(--rv-invite),var(--rv-invite-deep)); color:#fff!important; box-shadow:0 6px 18px rgba(22,163,74,.28); }
+    .rv-btn-invite:hover{ color:#fff!important; }
+    .rv-btn-ghost{ border-color:var(--rv-line); color:var(--rv-ink)!important; background:var(--rv-card); }
+
+    .rv-hero{ position:relative; overflow:hidden; }
+    .rv-hero::before{ content:""; position:absolute; inset:-30% -10% auto -10%; height:520px; background:radial-gradient(60% 70% at 72% 18%,var(--rv-brand-soft),transparent 70%); z-index:0; pointer-events:none; }
+    .rv-hero-grid{ position:relative; z-index:1; display:grid; grid-template-columns:1.02fr .98fr; gap:3rem; align-items:center; padding-top:4rem; padding-bottom:4rem; }
+    .rv-sub{ font-size:1.2rem; color:var(--rv-ink-soft); margin:1.2rem 0 1.8rem; max-width:34ch; }
+    .rv-cta-row{ display:flex; gap:.8rem; flex-wrap:wrap; align-items:center; }
+    .rv-reassure{ list-style:none; padding:0; margin:1.2rem 0 0; display:flex; gap:1.1rem; flex-wrap:wrap; font-size:.92rem; color:var(--rv-ink-faint); }
+    .rv-reassure li{ display:inline-flex; gap:.4rem; align-items:center; }
+    .rv-tick{ color:var(--rv-invite); font-weight:700; }
+    @media (max-width:860px){ .rv-hero-grid{ grid-template-columns:1fr; gap:2.2rem; } }
+
+    .rv-browser{ border-radius:14px; overflow:hidden; box-shadow:var(--rv-shadow-l); border:1px solid var(--rv-line); background:var(--rv-card); }
+    .rv-chrome{ display:flex; align-items:center; gap:.5rem; padding:.6rem .85rem; border-bottom:1px solid var(--rv-line); }
+    .rv-chrome i{ width:11px; height:11px; border-radius:50%; background:var(--rv-line); }
+    .rv-addr{ margin-left:.6rem; font-size:.78rem; color:var(--rv-ink-faint); background:var(--rv-band); border:1px solid var(--rv-line); border-radius:6px; padding:.22rem .7rem; display:inline-flex; align-items:center; gap:.4rem; }
+    .rv-browser picture{ display:block; }
+    .rv-browser img{ display:block; width:100%; height:auto; }
+
+    .rv-whatis{ display:grid; grid-template-columns:1fr 1fr; gap:2.5rem; align-items:center; }
+    .rv-lede{ font-size:1.3rem; line-height:1.5; color:var(--rv-ink); margin:0; }
+    .rv-lede strong{ color:var(--rv-brand); }
+    .rv-shapes{ display:grid; gap:.9rem; }
+    .rv-shape{ background:var(--rv-card); border:1px solid var(--rv-line); border-radius:12px; padding:1rem 1.15rem; box-shadow:var(--rv-shadow); }
+    .rv-shape-lbl{ font-family:var(--font-display); font-size:.72rem; letter-spacing:.1em; text-transform:uppercase; color:var(--rv-ink-faint); }
+    .rv-flow{ display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; margin-top:.45rem; }
+    .rv-chip{ font-family:var(--font-display); background:var(--rv-brand-soft); color:var(--rv-brand); border-radius:7px; padding:.15rem .6rem; font-size:.86rem; font-weight:600; }
+    .rv-chip-gone{ background:transparent; color:var(--rv-ink-faint); border:1px dashed var(--rv-line); text-decoration:line-through; }
+    .rv-arw{ color:var(--rv-ink-faint); }
+    .rv-shape-note{ color:var(--rv-ink-faint); font-size:.85rem; }
+    @media (max-width:820px){ .rv-whatis{ grid-template-columns:1fr; gap:1.6rem; } }
+
+    .rv-pillars{ display:grid; grid-template-columns:repeat(4,1fr); gap:1.2rem; }
+    .rv-pillar{ background:var(--rv-card); border:1px solid var(--rv-line); border-radius:14px; padding:1.5rem; box-shadow:var(--rv-shadow); }
+    .rv-ic{ width:44px; height:44px; border-radius:11px; display:grid; place-items:center; background:var(--rv-brand-soft); color:var(--rv-brand); margin-bottom:1rem; }
+    .rv-ic svg{ width:22px; height:22px; }
+    .rv-pillar-t{ font-size:1.12rem; font-weight:600; margin:0 0 .45rem; }
+    .rv-pillar p{ margin:0; font-size:.98rem; color:var(--rv-ink-soft); line-height:1.55; }
+    @media (max-width:900px){ .rv-pillars{ grid-template-columns:1fr 1fr; } }
+    @media (max-width:520px){ .rv-pillars{ grid-template-columns:1fr; } }
+
+    .rv-steps{ list-style:none; padding:0; margin:0; display:grid; grid-template-columns:repeat(3,1fr); gap:1.3rem; counter-reset:rvstep; }
+    .rv-step{ position:relative; background:var(--rv-card); border:1px solid var(--rv-line); border-radius:14px; padding:1.7rem 1.4rem 1.4rem; box-shadow:var(--rv-shadow); }
+    .rv-step::before{ counter-increment:rvstep; content:counter(rvstep); position:absolute; top:-16px; left:1.4rem; width:34px; height:34px; border-radius:50%; background:linear-gradient(135deg,var(--rv-invite),var(--rv-invite-deep)); color:#fff; font-family:var(--font-display); font-weight:700; display:grid; place-items:center; box-shadow:0 4px 12px rgba(22,163,74,.3); }
+    .rv-step-t{ font-size:1.08rem; font-weight:600; margin:.5rem 0 .4rem; }
+    .rv-step p{ margin:0; font-size:.96rem; color:var(--rv-ink-soft); }
+    .rv-join-cta{ margin-top:2rem; }
+    .rv-join-note{ margin:1rem 0 0; font-size:.95rem; color:var(--rv-ink-faint); }
+    @media (max-width:820px){ .rv-steps{ grid-template-columns:1fr; gap:1.9rem; } }
+
+    .rv-features{ display:grid; grid-template-columns:1fr 1fr; gap:.4rem 2.2rem; }
+    .rv-feat{ display:flex; gap:.85rem; padding:.75rem 0; border-bottom:1px solid var(--rv-line); }
+    .rv-fic{ color:var(--rv-brand); flex:0 0 auto; margin-top:.1rem; line-height:0; }
+    .rv-feat b{ font-family:var(--font-display); font-weight:600; }
+    .rv-feat span{ color:var(--rv-ink-soft); font-size:.96rem; display:block; }
+    @media (max-width:720px){ .rv-features{ grid-template-columns:1fr; } }
+
+    .rv-compare{ display:grid; gap:.7rem; }
+    .rv-crow{ display:grid; grid-template-columns:180px 1fr; gap:1.2rem; align-items:baseline; padding:.85rem 1.1rem; background:var(--rv-card); border:1px solid var(--rv-line); border-radius:11px; }
+    .rv-who{ font-family:var(--font-display); font-weight:600; }
+    .rv-what{ color:var(--rv-ink-soft); font-size:.98rem; }
+    .rv-crow-river{ background:var(--rv-brand-soft); border-color:transparent; }
+    .rv-crow-river .rv-who{ color:var(--rv-brand); }
+    .rv-crow-river .rv-what{ color:var(--rv-ink); }
+    @media (max-width:620px){ .rv-crow{ grid-template-columns:1fr; gap:.2rem; } }
+
+    .rv-privacy{ display:grid; grid-template-columns:1fr 1fr; gap:1.1rem 2.4rem; }
+    .rv-pv{ display:flex; gap:.8rem; }
+    .rv-pv-k{ color:var(--rv-invite); flex:0 0 auto; margin-top:.1rem; line-height:0; }
+    .rv-pv b{ font-family:var(--font-display); }
+    .rv-pv span{ color:var(--rv-ink-soft); font-size:.96rem; display:block; }
+    @media (max-width:700px){ .rv-privacy{ grid-template-columns:1fr; } }
+
+    .rv-final-box{ background:linear-gradient(135deg,#0066CC,#004C99); color:#fff; border-radius:20px; padding:3.2rem 2rem; box-shadow:var(--rv-shadow-l); text-align:center; }
+    .rv-final-box .rv-h2{ color:#fff; }
+    .rv-final-box p{ color:rgba(255,255,255,.9); max-width:46ch; margin:.9rem auto 1.7rem; }
+    .rv-final-cta{ display:flex; gap:.8rem; justify-content:center; flex-wrap:wrap; }
+    .rv-btn-oncolor{ background:#fff; color:var(--rv-invite)!important; }
+    .rv-btn-ghost-oncolor{ background:transparent; border-color:rgba(255,255,255,.5); color:#fff!important; }
+
+    @media (prefers-reduced-motion: reduce){ .river-page *{ transition:none!important; } }
+    </style>
+</head>
+{{/*
+  Dedicated base template for the River landing page.
+  Mirrors _default/baseof.html, but lets <main> run full-bleed so the page can
+  use edge-to-edge tinted bands like a product landing page. The site nav and
+  the institutional footer stay inside .container so they match every other
+  page. Keep this in sync with _default/baseof.html when the header/footer
+  wrapper changes.
+*/}}
+<body class="river-page">
+    <div class="container">
+        <header>
+            {{ partial "header.html" . }}
+        </header>
+    </div>
+    <main>
+        {{ block "main" . }}{{ end }}
+    </main>
+    <div class="container">
+        <footer>
+            {{ partial "footer.html" . }}
+            <div class="footer-content" style="text-align: center;">
+                <p>&copy; 2024-{{ now.Year }} Freenet Project Inc. src:
+                    <a href="https://github.com/freenet/web"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 98 96" style="vertical-align: middle;"><path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362l-.08-9.127c-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6C29.304 70.188 17.196 65.95 17.196 46.94c0-5.867 2.024-10.645 5.42-14.394-.572-1.143-2.347-6.845.486-14.23 0 0 4.447-1.47 14.56 5.54 4.204-1.226 8.733-1.796 13.19-1.796 4.457 0 8.986.57 13.19 1.796 10.112-6.847 14.56-5.54 14.56-5.54 2.833 7.385 1.058 13.087.486 14.23 3.396 3.749 5.42 8.527 5.42 14.394 0 19.01-11.944 23.248-23.403 24.472 1.862 1.633 3.477 4.745 3.477 9.572l-.08 14.232c0 1.303.89 2.852 3.316 2.362 19.412-6.518 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/></svg> <span
+                            style="font-weight: 600;">freenet/web</span></a>.
+        </footer>
+    </div>
+</body>
+</html>

--- a/hugo-site/themes/freenet/layouts/river/baseof.html
+++ b/hugo-site/themes/freenet/layouts/river/baseof.html
@@ -3,101 +3,126 @@
       dir="{{ or site.Language.LanguageDirection `ltr` }}">
 <head>
     {{ partial "head.html" . }}
+    {{/* Social card for /river */}}
+    <meta property="og:title" content="{{ .Title }}">
+    <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{ .Summary }}{{ end }}">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{ .Permalink }}">
+    <meta property="og:image" content="{{ "images/river-screenshot-light.png" | absURL }}">
+    <meta name="twitter:card" content="summary_large_image">
     <style>
     /* ===== River landing page (scoped to .river-page; loads only on /river) ===== */
     .river-page{
       --rv-brand:#0066CC; --rv-brand-deep:#004C99; --rv-brand-bright:#00a6ff;
-      --rv-invite:#16a34a; --rv-invite-deep:#12833f;
       --rv-band:#eef4fb; --rv-card:#ffffff;
       --rv-ink:#0f1b2d; --rv-ink-soft:#48586b; --rv-ink-faint:#6b7a8d;
-      --rv-line:rgba(15,27,45,.09); --rv-brand-soft:rgba(0,102,204,.09);
-      --rv-shadow:0 10px 34px rgba(15,40,80,.10); --rv-shadow-l:0 22px 60px rgba(15,40,80,.16);
+      --rv-line:rgba(15,27,45,.09); --rv-brand-soft:rgba(0,102,204,.09); --rv-dot:#c8d2de;
+      --rv-shadow:0 1px 2px rgba(15,40,80,.05), 0 6px 18px rgba(15,40,80,.06);
+      --rv-shadow-l:0 12px 34px rgba(15,40,80,.12);
     }
     @media (prefers-color-scheme: dark){
       .river-page{
         --rv-band:#171b22; --rv-card:#1e222b;
-        --rv-ink:#f2f5f8; --rv-ink-soft:#aebccb; --rv-ink-faint:#8595a6;
-        --rv-line:rgba(255,255,255,.09); --rv-brand:#4da6ff; --rv-brand-bright:#5cc0ff;
-        --rv-brand-soft:rgba(77,166,255,.12); --rv-invite:#34d17f;
-        --rv-shadow:0 10px 34px rgba(0,0,0,.45); --rv-shadow-l:0 22px 60px rgba(0,0,0,.55);
+        --rv-ink:#f2f5f8; --rv-ink-soft:#aebccb; --rv-ink-faint:#93a2b3;
+        --rv-line:rgba(255,255,255,.10); --rv-brand:#4da6ff; --rv-brand-bright:#5cc0ff;
+        --rv-brand-soft:rgba(77,166,255,.14); --rv-dot:#3a424e;
+        --rv-shadow:0 1px 2px rgba(0,0,0,.4), 0 6px 18px rgba(0,0,0,.4);
+        --rv-shadow-l:0 14px 40px rgba(0,0,0,.55);
       }
     }
 
     .rv-wrap{ max-width:1080px; margin:0 auto; padding:0 22px; }
     .rv-section{ padding:4rem 0; }
     .rv-band{ padding:4rem 0; background:var(--rv-band); border-top:1px solid var(--rv-line); border-bottom:1px solid var(--rv-line); }
-    .rv-eyebrow{ font-family:var(--font-display); font-weight:600; font-size:.8rem; letter-spacing:.13em; text-transform:uppercase; color:var(--rv-brand); margin:0 0 .9rem; }
-    .rv-h1{ font-size:clamp(2.4rem,5vw,3.5rem); font-weight:700; line-height:1.06; margin:0; letter-spacing:-.02em; text-wrap:balance; }
-    .rv-grad{ background:linear-gradient(115deg,var(--rv-brand-deep),var(--rv-brand) 45%,var(--rv-brand-bright)); -webkit-background-clip:text; background-clip:text; -webkit-text-fill-color:transparent; }
-    @media (prefers-color-scheme: dark){ .rv-grad{ background:linear-gradient(135deg,#4da6ff,#0066CC 50%,#00a6ff); -webkit-background-clip:text; background-clip:text; -webkit-text-fill-color:transparent; } }
+    .rv-eyebrow{ font-family:var(--font-display); font-weight:600; font-size:.8rem; letter-spacing:.13em; text-transform:uppercase; color:var(--rv-brand); margin:0 0 .7rem; }
+    .rv-h1{ font-size:clamp(2.4rem,5vw,3.4rem); font-weight:700; line-height:1.06; margin:0; letter-spacing:-.02em; text-wrap:balance; }
+    .rv-grad{ color:var(--rv-brand); }
     .rv-h2{ font-size:clamp(1.7rem,3.4vw,2.3rem); font-weight:700; margin:0; text-wrap:balance; }
-    .rv-head{ max-width:44ch; margin-bottom:2.4rem; }
-    .rv-head-sub{ color:var(--rv-ink-soft); margin:.8rem 0 0; }
-    .rv-center{ text-align:center; margin-left:auto; margin-right:auto; }
+    .rv-head{ margin-bottom:2.4rem; }
+    .rv-head-sub{ color:var(--rv-ink-soft); margin:.8rem 0 0; max-width:54ch; }
+    .rv-center{ text-align:center; }
+    .rv-center .rv-head-sub{ margin-left:auto; margin-right:auto; }
 
-    .rv-btn{ display:inline-flex; align-items:center; gap:.5rem; font-family:var(--font-display); font-weight:600; font-size:1.02rem; padding:.85rem 1.6rem; border-radius:10px; border:1.5px solid transparent; cursor:pointer; transition:transform .15s ease, box-shadow .15s ease; text-decoration:none; }
+    .rv-btn{ display:inline-flex; align-items:center; gap:.5rem; font-family:var(--font-display); font-weight:600; font-size:1.02rem; padding:.85rem 1.6rem; border-radius:10px; border:1.5px solid transparent; cursor:pointer; transition:transform .15s ease, box-shadow .15s ease, background .15s ease; text-decoration:none; }
     .rv-btn:hover{ transform:translateY(-1px); }
-    .rv-btn-invite{ background:linear-gradient(135deg,var(--rv-invite),var(--rv-invite-deep)); color:#fff!important; box-shadow:0 6px 18px rgba(22,163,74,.28); }
-    .rv-btn-invite:hover{ color:#fff!important; }
+    .rv-btn-invite{ background:#0b6e33; color:#fff!important; box-shadow:0 4px 14px rgba(11,110,51,.28); }
+    .rv-btn-invite:hover{ background:#095a2a; color:#fff!important; }
+    @media (prefers-color-scheme: dark){
+      .rv-btn-invite{ background:#34d17f; color:#06251a!important; box-shadow:0 4px 14px rgba(0,0,0,.4); }
+      .rv-btn-invite:hover{ background:#28b86c; color:#06251a!important; }
+    }
     .rv-btn-ghost{ border-color:var(--rv-line); color:var(--rv-ink)!important; background:var(--rv-card); }
 
+    /* hero */
     .rv-hero{ position:relative; overflow:hidden; }
     .rv-hero::before{ content:""; position:absolute; inset:-30% -10% auto -10%; height:520px; background:radial-gradient(60% 70% at 72% 18%,var(--rv-brand-soft),transparent 70%); z-index:0; pointer-events:none; }
-    .rv-hero-grid{ position:relative; z-index:1; display:grid; grid-template-columns:1.02fr .98fr; gap:3rem; align-items:center; padding-top:4rem; padding-bottom:4rem; }
-    .rv-sub{ font-size:1.2rem; color:var(--rv-ink-soft); margin:1.2rem 0 1.8rem; max-width:34ch; }
+    .rv-hero-grid{ position:relative; z-index:1; display:grid; grid-template-columns:1.02fr .98fr; gap:3rem; align-items:center; padding-top:3.6rem; padding-bottom:4rem; }
+    .rv-brandmark{ display:flex; align-items:center; gap:.55rem; margin-bottom:1.3rem; }
+    .rv-mark{ width:52px; height:52px; display:block; }
+    .rv-wordmark{ font-family:var(--font-display); font-weight:700; font-size:2.2rem; letter-spacing:-.02em; color:var(--rv-ink); line-height:1; }
+    .rv-brand-tag{ font-family:var(--font-display); font-weight:600; font-size:.7rem; letter-spacing:.1em; text-transform:uppercase; color:var(--rv-ink-faint); border:1px solid var(--rv-line); border-radius:999px; padding:.28rem .62rem; margin-left:.25rem; }
+    .rv-sub{ font-size:1.2rem; color:var(--rv-ink-soft); margin:1.1rem 0 1.7rem; max-width:36ch; }
     .rv-cta-row{ display:flex; gap:.8rem; flex-wrap:wrap; align-items:center; }
     .rv-reassure{ list-style:none; padding:0; margin:1.2rem 0 0; display:flex; gap:1.1rem; flex-wrap:wrap; font-size:.92rem; color:var(--rv-ink-faint); }
-    .rv-reassure li{ display:inline-flex; gap:.4rem; align-items:center; }
-    .rv-tick{ color:var(--rv-invite); font-weight:700; }
-    @media (max-width:860px){ .rv-hero-grid{ grid-template-columns:1fr; gap:2.2rem; } }
+    .rv-reassure li{ display:inline-flex; gap:.45rem; align-items:center; }
+    .rv-tick{ color:var(--rv-brand); line-height:0; }
+    .rv-tick svg{ width:15px; height:15px; }
+    @media (max-width:860px){ .rv-hero-grid{ grid-template-columns:1fr; gap:2.2rem; padding-top:2.6rem; } }
 
+    /* browser frame */
     .rv-browser{ border-radius:14px; overflow:hidden; box-shadow:var(--rv-shadow-l); border:1px solid var(--rv-line); background:var(--rv-card); }
     .rv-chrome{ display:flex; align-items:center; gap:.5rem; padding:.6rem .85rem; border-bottom:1px solid var(--rv-line); }
-    .rv-chrome i{ width:11px; height:11px; border-radius:50%; background:var(--rv-line); }
+    .rv-chrome i{ width:11px; height:11px; border-radius:50%; background:var(--rv-dot); }
     .rv-addr{ margin-left:.6rem; font-size:.78rem; color:var(--rv-ink-faint); background:var(--rv-band); border:1px solid var(--rv-line); border-radius:6px; padding:.22rem .7rem; display:inline-flex; align-items:center; gap:.4rem; }
     .rv-browser picture{ display:block; }
     .rv-browser img{ display:block; width:100%; height:auto; }
 
+    /* what-is */
     .rv-whatis{ display:grid; grid-template-columns:1fr 1fr; gap:2.5rem; align-items:center; }
-    .rv-lede{ font-size:1.3rem; line-height:1.5; color:var(--rv-ink); margin:0; }
+    .rv-whatis .rv-eyebrow{ margin-bottom:.5rem; }
+    .rv-whatis .rv-h2{ margin-bottom:1rem; }
+    .rv-lede{ font-size:1.25rem; line-height:1.5; color:var(--rv-ink); margin:0; }
     .rv-lede strong{ color:var(--rv-brand); }
     .rv-shapes{ display:grid; gap:.9rem; }
     .rv-shape{ background:var(--rv-card); border:1px solid var(--rv-line); border-radius:12px; padding:1rem 1.15rem; box-shadow:var(--rv-shadow); }
     .rv-shape-lbl{ font-family:var(--font-display); font-size:.72rem; letter-spacing:.1em; text-transform:uppercase; color:var(--rv-ink-faint); }
     .rv-flow{ display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; margin-top:.45rem; }
     .rv-chip{ font-family:var(--font-display); background:var(--rv-brand-soft); color:var(--rv-brand); border-radius:7px; padding:.15rem .6rem; font-size:.86rem; font-weight:600; }
-    .rv-chip-gone{ background:transparent; color:var(--rv-ink-faint); border:1px dashed var(--rv-line); text-decoration:line-through; }
+    .rv-chip-gone{ background:transparent; color:var(--rv-ink-soft); border:1px dashed var(--rv-ink-faint); text-decoration:line-through; }
     .rv-arw{ color:var(--rv-ink-faint); }
-    .rv-shape-note{ color:var(--rv-ink-faint); font-size:.85rem; }
+    .rv-shape-note{ color:var(--rv-ink-soft); font-size:.85rem; }
     @media (max-width:820px){ .rv-whatis{ grid-template-columns:1fr; gap:1.6rem; } }
 
+    /* pillars */
     .rv-pillars{ display:grid; grid-template-columns:repeat(4,1fr); gap:1.2rem; }
     .rv-pillar{ background:var(--rv-card); border:1px solid var(--rv-line); border-radius:14px; padding:1.5rem; box-shadow:var(--rv-shadow); }
-    .rv-ic{ width:44px; height:44px; border-radius:11px; display:grid; place-items:center; background:var(--rv-brand-soft); color:var(--rv-brand); margin-bottom:1rem; }
-    .rv-ic svg{ width:22px; height:22px; }
+    .rv-ic{ color:var(--rv-brand); margin-bottom:.9rem; display:block; }
+    .rv-ic svg{ width:30px; height:30px; }
     .rv-pillar-t{ font-size:1.12rem; font-weight:600; margin:0 0 .45rem; }
     .rv-pillar p{ margin:0; font-size:.98rem; color:var(--rv-ink-soft); line-height:1.55; }
     @media (max-width:900px){ .rv-pillars{ grid-template-columns:1fr 1fr; } }
     @media (max-width:520px){ .rv-pillars{ grid-template-columns:1fr; } }
 
-    .rv-steps{ list-style:none; padding:0; margin:0; display:grid; grid-template-columns:repeat(3,1fr); gap:1.3rem; counter-reset:rvstep; }
-    .rv-step{ position:relative; background:var(--rv-card); border:1px solid var(--rv-line); border-radius:14px; padding:1.7rem 1.4rem 1.4rem; box-shadow:var(--rv-shadow); }
-    .rv-step::before{ counter-increment:rvstep; content:counter(rvstep); position:absolute; top:-16px; left:1.4rem; width:34px; height:34px; border-radius:50%; background:linear-gradient(135deg,var(--rv-invite),var(--rv-invite-deep)); color:#fff; font-family:var(--font-display); font-weight:700; display:grid; place-items:center; box-shadow:0 4px 12px rgba(22,163,74,.3); }
-    .rv-step-t{ font-size:1.08rem; font-weight:600; margin:.5rem 0 .4rem; }
+    /* steps */
+    .rv-steps{ list-style:none; padding:0; margin:0; display:grid; grid-template-columns:repeat(3,1fr); gap:1.3rem; text-align:left; }
+    .rv-step{ background:var(--rv-card); border:1px solid var(--rv-line); border-radius:14px; padding:1.5rem 1.4rem; box-shadow:var(--rv-shadow); }
+    .rv-step-n{ font-family:var(--font-display); font-weight:700; font-size:1.6rem; color:var(--rv-brand); line-height:1; display:block; margin-bottom:.5rem; }
+    .rv-step-t{ font-size:1.08rem; font-weight:600; margin:0 0 .4rem; }
     .rv-step p{ margin:0; font-size:.96rem; color:var(--rv-ink-soft); }
     .rv-join-cta{ margin-top:2rem; }
-    .rv-join-note{ margin:1rem 0 0; font-size:.95rem; color:var(--rv-ink-faint); }
-    @media (max-width:820px){ .rv-steps{ grid-template-columns:1fr; gap:1.9rem; } }
+    @media (max-width:820px){ .rv-steps{ grid-template-columns:1fr; gap:1rem; } }
 
-    .rv-features{ display:grid; grid-template-columns:1fr 1fr; gap:.4rem 2.2rem; }
-    .rv-feat{ display:flex; gap:.85rem; padding:.75rem 0; border-bottom:1px solid var(--rv-line); }
-    .rv-fic{ color:var(--rv-brand); flex:0 0 auto; margin-top:.1rem; line-height:0; }
+    /* features */
+    .rv-features{ display:grid; grid-template-columns:1fr 1fr; gap:1.3rem 2.4rem; }
+    .rv-feat{ display:flex; gap:.85rem; }
+    .rv-fic{ color:var(--rv-brand); flex:0 0 auto; margin-top:.05rem; line-height:0; }
     .rv-feat b{ font-family:var(--font-display); font-weight:600; }
-    .rv-feat span{ color:var(--rv-ink-soft); font-size:.96rem; display:block; }
+    .rv-feat span{ color:var(--rv-ink-soft); font-size:.96rem; display:block; margin-top:.1rem; }
     @media (max-width:720px){ .rv-features{ grid-template-columns:1fr; } }
 
+    /* compare */
     .rv-compare{ display:grid; gap:.7rem; }
-    .rv-crow{ display:grid; grid-template-columns:180px 1fr; gap:1.2rem; align-items:baseline; padding:.85rem 1.1rem; background:var(--rv-card); border:1px solid var(--rv-line); border-radius:11px; }
+    .rv-crow{ display:grid; grid-template-columns:170px 1fr; gap:1.2rem; align-items:baseline; padding:.85rem 1.1rem; background:var(--rv-card); border:1px solid var(--rv-line); border-radius:11px; }
     .rv-who{ font-family:var(--font-display); font-weight:600; }
     .rv-what{ color:var(--rv-ink-soft); font-size:.98rem; }
     .rv-crow-river{ background:var(--rv-brand-soft); border-color:transparent; }
@@ -105,19 +130,24 @@
     .rv-crow-river .rv-what{ color:var(--rv-ink); }
     @media (max-width:620px){ .rv-crow{ grid-template-columns:1fr; gap:.2rem; } }
 
+    /* privacy */
     .rv-privacy{ display:grid; grid-template-columns:1fr 1fr; gap:1.1rem 2.4rem; }
     .rv-pv{ display:flex; gap:.8rem; }
-    .rv-pv-k{ color:var(--rv-invite); flex:0 0 auto; margin-top:.1rem; line-height:0; }
+    .rv-pv-k{ color:var(--rv-brand); flex:0 0 auto; margin-top:.05rem; line-height:0; }
     .rv-pv b{ font-family:var(--font-display); }
-    .rv-pv span{ color:var(--rv-ink-soft); font-size:.96rem; display:block; }
+    .rv-pv span{ color:var(--rv-ink-soft); font-size:.96rem; display:block; margin-top:.1rem; }
+    .rv-privacy-note{ margin:1.7rem 0 0; font-size:.95rem; color:var(--rv-ink-soft); max-width:74ch; }
     @media (max-width:700px){ .rv-privacy{ grid-template-columns:1fr; } }
 
+    /* final */
+    .rv-alpha{ text-align:center; max-width:62ch; margin:0 auto 1.6rem; font-size:.95rem; color:var(--rv-ink-faint); }
     .rv-final-box{ background:linear-gradient(135deg,#0066CC,#004C99); color:#fff; border-radius:20px; padding:3.2rem 2rem; box-shadow:var(--rv-shadow-l); text-align:center; }
     .rv-final-box .rv-h2{ color:#fff; }
     .rv-final-box p{ color:rgba(255,255,255,.9); max-width:46ch; margin:.9rem auto 1.7rem; }
     .rv-final-cta{ display:flex; gap:.8rem; justify-content:center; flex-wrap:wrap; }
-    .rv-btn-oncolor{ background:#fff; color:var(--rv-invite)!important; }
-    .rv-btn-ghost-oncolor{ background:transparent; border-color:rgba(255,255,255,.5); color:#fff!important; }
+    .rv-btn-oncolor{ background:#fff; color:#0066CC!important; }
+    .rv-btn-oncolor:hover{ color:#004C99!important; }
+    .rv-btn-ghost-oncolor{ background:transparent; border-color:rgba(255,255,255,.55); color:#fff!important; }
 
     @media (prefers-reduced-motion: reduce){ .river-page *{ transition:none!important; } }
     </style>

--- a/hugo-site/themes/freenet/layouts/river/list.html
+++ b/hugo-site/themes/freenet/layouts/river/list.html
@@ -1,0 +1,209 @@
+{{ define "main" }}
+{{- $light := "images/river-screenshot-light.png" | relURL -}}
+{{- $dark := "images/river-screenshot-dark.png" | relURL -}}
+
+<!-- ===================== HERO ===================== -->
+<header class="rv-hero">
+  <div class="rv-wrap rv-hero-grid">
+    <div class="rv-hero-copy">
+      <p class="rv-eyebrow">River &middot; built on Freenet</p>
+      <h1 class="rv-h1">Group chat with <span class="rv-grad">no servers.</span></h1>
+      <p class="rv-sub">Encrypted group rooms that live on Freenet, a global peer-to-peer network, instead of anyone's servers. No company, no account, no phone number.</p>
+      <div class="rv-cta-row">
+        <a class="rv-btn rv-btn-invite" href="{{ "quickstart/" | relURL }}">Get an invite
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        </a>
+        <a class="rv-btn rv-btn-ghost" href="#how">How it works</a>
+      </div>
+      <ul class="rv-reassure">
+        <li><span class="rv-tick">&#10003;</span> Runs in your browser</li>
+        <li><span class="rv-tick">&#10003;</span> End-to-end encrypted</li>
+        <li><span class="rv-tick">&#10003;</span> Open source</li>
+      </ul>
+    </div>
+    <div class="rv-hero-shot">
+      <div class="rv-browser">
+        <div class="rv-chrome">
+          <i></i><i></i><i></i>
+          <span class="rv-addr">
+            <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>
+            River &mdash; running on your Freenet peer
+          </span>
+        </div>
+        <picture>
+          <source srcset="{{ $dark }}" media="(prefers-color-scheme: dark)">
+          <img src="{{ $light }}" alt="A live River chat room, the Freenet Official room, with a member list and messages" width="1379" height="1269" loading="eager">
+        </picture>
+      </div>
+    </div>
+  </div>
+</header>
+
+<!-- ============ WAIT, NO SERVERS? (explainer) ============ -->
+<section class="rv-band" id="how">
+  <div class="rv-wrap rv-whatis">
+    <div>
+      <p class="rv-eyebrow">Wait, no servers?</p>
+      <p class="rv-lede">Most chat apps send your messages to <strong>servers a company runs</strong>. River sends them to <strong>Freenet</strong>, a network made of its users' own computers. Each room lives on the network itself, so it keeps working even if the person who made it goes offline, and nobody has a server to shut down, snoop on, or bill.</p>
+    </div>
+    <div class="rv-shapes">
+      <div class="rv-shape">
+        <span class="rv-shape-lbl">A normal chat app</span>
+        <div class="rv-flow">
+          <span class="rv-chip">your browser</span><span class="rv-arw">&rarr;</span>
+          <span class="rv-chip rv-chip-gone">a company's servers</span><span class="rv-arw">&rarr;</span>
+          <span class="rv-chip rv-chip-gone">their database</span>
+        </div>
+      </div>
+      <div class="rv-shape">
+        <span class="rv-shape-lbl">River</span>
+        <div class="rv-flow">
+          <span class="rv-chip">your browser</span><span class="rv-arw">&rarr;</span>
+          <span class="rv-chip">Freenet</span>
+          <span class="rv-shape-note">a network nobody operates for River</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== PILLARS ===================== -->
+<section class="rv-section">
+  <div class="rv-wrap">
+    <div class="rv-head rv-center">
+      <h2 class="rv-h2">Chat that no one owns</h2>
+      <p class="rv-head-sub">The things that make River different are the things it leaves out.</p>
+    </div>
+    <div class="rv-pillars">
+      <div class="rv-pillar">
+        <span class="rv-ic">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><circle cx="4.5" cy="7" r="2"/><circle cx="19.5" cy="7" r="2"/><circle cx="4.5" cy="17" r="2"/><circle cx="19.5" cy="17" r="2"/><path d="M6.3 8.1 9.6 10.6M17.7 8.1 14.4 10.6M6.3 15.9 9.6 13.4M17.7 15.9 14.4 13.4"/></svg>
+        </span>
+        <h3 class="rv-pillar-t">No servers</h3>
+        <p>Every room lives on Freenet, hosted by the network's own peers. There's no backend for anyone to run, pay for, or take down.</p>
+      </div>
+      <div class="rv-pillar">
+        <span class="rv-ic">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M5 20c0-3.9 3.1-7 7-7s7 3.1 7 7"/></svg>
+        </span>
+        <h3 class="rv-pillar-t">No account</h3>
+        <p>No sign-up, no phone number, no email. Your identity is a key on your device, not a row in someone's database.</p>
+      </div>
+      <div class="rv-pillar">
+        <span class="rv-ic">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="10.5" width="16" height="10" rx="2"/><path d="M8 10.5V7a4 4 0 0 1 8 0v3.5"/><circle cx="12" cy="15.5" r="1.4"/></svg>
+        </span>
+        <h3 class="rv-pillar-t">Encrypted rooms</h3>
+        <p>Private rooms are end-to-end encrypted, and every message is signed, so any peer can host a room without being able to forge or read it.</p>
+      </div>
+      <div class="rv-pillar">
+        <span class="rv-ic">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2 4 14h7l-1 8 9-12h-7l1-8z"/></svg>
+        </span>
+        <h3 class="rv-pillar-t">Scales with demand</h3>
+        <p>A room in demand is cached on more peers, so it gets faster and more resilient as it grows, not slower. The opposite of the server model, where traffic is a bill.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ HOW YOU JOIN (invite flow) ============ -->
+<section class="rv-band" id="join">
+  <div class="rv-wrap">
+    <div class="rv-head rv-center">
+      <p class="rv-eyebrow">Getting in</p>
+      <h2 class="rv-h2">There's nothing to download</h2>
+      <p class="rv-head-sub">River isn't an app you install from a store. You install Freenet once, then rooms open right in your browser from an invite link.</p>
+    </div>
+    <ol class="rv-steps">
+      <li class="rv-step">
+        <h3 class="rv-step-t">Install Freenet</h3>
+        <p>One small background app runs a Freenet peer on your machine. Everything River needs rides on top of it.</p>
+      </li>
+      <li class="rv-step">
+        <h3 class="rv-step-t">Click an invite</h3>
+        <p>Get an invite to the official room, or from a friend. Rooms are invite-only, which is the membership model, not a paywall.</p>
+      </li>
+      <li class="rv-step">
+        <h3 class="rv-step-t">You're in the room</h3>
+        <p>River opens in your browser, on desktop or mobile. Create your own rooms and share their invite links the same way.</p>
+      </li>
+    </ol>
+    <div class="rv-center rv-join-cta">
+      <a class="rv-btn rv-btn-invite" href="{{ "quickstart/" | relURL }}">Install Freenet &amp; get an invite
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+      </a>
+      <p class="rv-join-note">Prefer a terminal? River is fully scriptable with <code>riverctl</code>, handy for bots and AI agents. See the <a href="https://github.com/freenet/river/blob/main/cli/README.md">riverctl guide</a>.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== FEATURES ===================== -->
+<section class="rv-section">
+  <div class="rv-wrap">
+    <div class="rv-head">
+      <p class="rv-eyebrow">Features</p>
+      <h2 class="rv-h2">Everything you expect from a group chat</h2>
+    </div>
+    <div class="rv-features">
+      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Real-time group chat</b><span>Live rooms that sync across every member as messages arrive.</span></div></div>
+      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Public &amp; private rooms</b><span>Open rooms anyone with a link can join, or end-to-end encrypted private ones.</span></div></div>
+      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>One-click invite links</b><span>Share a link; it opens River and joins the recipient to the room.</span></div></div>
+      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Invitation-tree moderation</b><span>Manage or ban anyone you invited, or anyone downstream of them.</span></div></div>
+      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Desktop &amp; mobile</b><span>Runs in the browser on both, with no separate app to install.</span></div></div>
+      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Command-line client</b><span><code>riverctl</code> drives rooms from a script, bots and agents included.</span></div></div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ WHY NOT ... (comparison) ============ -->
+<section class="rv-band">
+  <div class="rv-wrap">
+    <div class="rv-head">
+      <p class="rv-eyebrow">Why not Matrix, Discord, or Signal?</p>
+      <h2 class="rv-h2">They all keep a server somewhere</h2>
+      <p class="rv-head-sub">Other systems decentralize to different degrees, but each one still has a server that someone runs.</p>
+    </div>
+    <div class="rv-compare">
+      <div class="rv-crow"><span class="rv-who">Discord, Signal</span><span class="rv-what">Central servers, operated by a company.</span></div>
+      <div class="rv-crow"><span class="rv-who">Matrix</span><span class="rv-what">Federated homeservers, each one still run by someone.</span></div>
+      <div class="rv-crow"><span class="rv-who">Nostr</span><span class="rv-what">Relays, which are servers.</span></div>
+      <div class="rv-crow"><span class="rv-who">Briar, Tox</span><span class="rv-what">Serverless, but device-to-device: both people must be online, and there's no shared room the network keeps for you.</span></div>
+      <div class="rv-crow rv-crow-river"><span class="rv-who">River</span><span class="rv-what">Each room is state hosted by Freenet itself. No company server, no homeserver to pick, and rooms that persist when their creator is offline.</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== PRIVACY ===================== -->
+<section class="rv-section">
+  <div class="rv-wrap">
+    <div class="rv-head">
+      <p class="rv-eyebrow">Privacy by design</p>
+      <h2 class="rv-h2">Nothing in the middle to leak</h2>
+      <p class="rv-head-sub">Privacy in River isn't a mode you switch on. It's what's left when you remove the company, the account, and the server.</p>
+    </div>
+    <div class="rv-privacy">
+      <div class="rv-pv"><span class="rv-pv-k">{{ partial "inline/rv-check.html" . }}</span><div><b>No central server to subpoena or breach.</b><span>Rooms live on the network; there's no company database to hand over or hack.</span></div></div>
+      <div class="rv-pv"><span class="rv-pv-k">{{ partial "inline/rv-check.html" . }}</span><div><b>No phone number tied to your identity.</b><span>You never hand over a number or an email to sign up.</span></div></div>
+      <div class="rv-pv"><span class="rv-pv-k">{{ partial "inline/rv-check.html" . }}</span><div><b>End-to-end encryption on private rooms.</b><span>Only members can read them, not the peers hosting the data.</span></div></div>
+      <div class="rv-pv"><span class="rv-pv-k">{{ partial "inline/rv-check.html" . }}</span><div><b>Open source and auditable.</b><span>No blockchain, no token, no coins. Just code you can read on GitHub.</span></div></div>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== FINAL CTA ===================== -->
+<section class="rv-section rv-final">
+  <div class="rv-wrap">
+    <div class="rv-final-box">
+      <h2 class="rv-h2">See a decentralized network actually work</h2>
+      <p>Join the room where Freenet's developers and users hang out. It's the fastest way to watch peer-to-peer chat in action.</p>
+      <div class="rv-final-cta">
+        <a class="rv-btn rv-btn-oncolor" href="{{ "quickstart/" | relURL }}">Get an invite
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        </a>
+        <a class="rv-btn rv-btn-ghost-oncolor" href="{{ "build/manual/" | relURL }}">Read the docs</a>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}

--- a/hugo-site/themes/freenet/layouts/river/list.html
+++ b/hugo-site/themes/freenet/layouts/river/list.html
@@ -15,7 +15,7 @@
       <h1 class="rv-h1">Group chat with <span class="rv-grad">no servers.</span></h1>
       <p class="rv-sub">River is group chat that lives on Freenet, a global peer-to-peer network, instead of anyone's servers. No company, no account, no phone number.</p>
       <div class="rv-cta-row">
-        <a class="rv-btn rv-btn-invite" href="{{ "quickstart/" | relURL }}">Get an invite
+        <a class="rv-btn rv-btn-primary" href="{{ "quickstart/" | relURL }}">Try River
           <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
         </a>
         <a class="rv-btn rv-btn-ghost" href="#how">How it works</a>
@@ -139,7 +139,7 @@
       </li>
     </ol>
     <div class="rv-center rv-join-cta">
-      <a class="rv-btn rv-btn-invite" href="{{ "quickstart/" | relURL }}">Install Freenet &amp; get an invite
+      <a class="rv-btn rv-btn-primary" href="{{ "quickstart/" | relURL }}">Try River
         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
       </a>
     </div>
@@ -208,7 +208,7 @@
       <h2 class="rv-h2">The developers are in the room right now</h2>
       <p>Join the official room where Freenet's developers and users hang out. It's the fastest way to see peer-to-peer chat working.</p>
       <div class="rv-final-cta">
-        <a class="rv-btn rv-btn-oncolor" href="{{ "quickstart/" | relURL }}">Get an invite
+        <a class="rv-btn rv-btn-oncolor" href="{{ "quickstart/" | relURL }}">Try River
           <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
         </a>
         <a class="rv-btn rv-btn-ghost-oncolor" href="https://github.com/freenet/river">River on GitHub</a>

--- a/hugo-site/themes/freenet/layouts/river/list.html
+++ b/hugo-site/themes/freenet/layouts/river/list.html
@@ -159,7 +159,7 @@
       <div class="rv-crow"><span class="rv-who">Matrix</span><span class="rv-what">Federated homeservers, each one still run by someone.</span></div>
       <div class="rv-crow"><span class="rv-who">Nostr</span><span class="rv-what">Relays, which are servers.</span></div>
       <div class="rv-crow"><span class="rv-who">Briar, Tox</span><span class="rv-what">Serverless, but device-to-device: both people must be online, and there's no shared room the network keeps for you.</span></div>
-      <div class="rv-crow rv-crow-river"><span class="rv-who">River</span><span class="rv-what">Each room lives on Freenet itself. No company server, no homeserver to pick, and rooms that persist when their creator is offline.</span></div>
+      <div class="rv-crow rv-crow-river"><span class="rv-who">River</span><span class="rv-what">Each room lives on Freenet itself: the network keeps the room for you, with no company server and no homeserver to run.</span></div>
     </div>
   </div>
 </section>
@@ -176,7 +176,6 @@
       <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Public &amp; private rooms</b><span>Public rooms anyone can read, or private rooms only members can decrypt.</span></div></div>
       <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>One-click invite links</b><span>Share a link; it opens River and joins the recipient to the room.</span></div></div>
       <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Invitation-tree moderation</b><span>Manage or ban anyone you invited, or anyone downstream of them.</span></div></div>
-      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Always-on rooms</b><span>A room stays live on the network even when the person who created it is offline.</span></div></div>
       <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Command-line client</b><span><code>riverctl</code> drives rooms from a script, bots and agents included.</span></div></div>
     </div>
   </div>

--- a/hugo-site/themes/freenet/layouts/river/list.html
+++ b/hugo-site/themes/freenet/layouts/river/list.html
@@ -176,7 +176,7 @@
       <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Public &amp; private rooms</b><span>Public rooms anyone can read, or private rooms only members can decrypt.</span></div></div>
       <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>One-click invite links</b><span>Share a link; it opens River and joins the recipient to the room.</span></div></div>
       <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Invitation-tree moderation</b><span>Manage or ban anyone you invited, or anyone downstream of them.</span></div></div>
-      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Desktop &amp; mobile</b><span>Runs in the browser on both, with no separate app to install.</span></div></div>
+      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Always-on rooms</b><span>A room stays live on the network even when the person who created it is offline.</span></div></div>
       <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Command-line client</b><span><code>riverctl</code> drives rooms from a script, bots and agents included.</span></div></div>
     </div>
   </div>

--- a/hugo-site/themes/freenet/layouts/river/list.html
+++ b/hugo-site/themes/freenet/layouts/river/list.html
@@ -12,7 +12,7 @@
         <span class="rv-wordmark">River</span>
         <span class="rv-brand-tag">built on Freenet</span>
       </div>
-      <h1 class="rv-h1">Group chat with <span class="rv-grad">no servers.</span></h1>
+      <h1 class="rv-h1">Group chat with <span class="rv-grad">no company in the middle.</span></h1>
       <p class="rv-sub">River is group chat that lives on Freenet, a global peer-to-peer network, instead of anyone's servers. No company, no account, no phone number.</p>
       <div class="rv-cta-row">
         <a class="rv-btn rv-btn-primary" href="{{ "quickstart/" | relURL }}">Try River

--- a/hugo-site/themes/freenet/layouts/river/list.html
+++ b/hugo-site/themes/freenet/layouts/river/list.html
@@ -21,9 +21,9 @@
         <a class="rv-btn rv-btn-ghost" href="#how">How it works</a>
       </div>
       <ul class="rv-reassure">
-        <li><span class="rv-tick">{{ partial "inline/rv-check.html" . }}</span> Runs in your browser</li>
+        <li><span class="rv-tick">{{ partial "inline/rv-check.html" . }}</span> Quick, easy install</li>
         <li><span class="rv-tick">{{ partial "inline/rv-check.html" . }}</span> No account, no phone number</li>
-        <li><span class="rv-tick">{{ partial "inline/rv-check.html" . }}</span> Open source</li>
+        <li><span class="rv-tick">{{ partial "inline/rv-check.html" . }}</span> Free and open source</li>
       </ul>
     </div>
     <div class="rv-hero-shot">

--- a/hugo-site/themes/freenet/layouts/river/list.html
+++ b/hugo-site/themes/freenet/layouts/river/list.html
@@ -1,14 +1,19 @@
 {{ define "main" }}
 {{- $light := "images/river-screenshot-light.png" | relURL -}}
 {{- $dark := "images/river-screenshot-dark.png" | relURL -}}
+{{- $logo := "images/river_logo.svg" | relURL -}}
 
 <!-- ===================== HERO ===================== -->
 <header class="rv-hero">
   <div class="rv-wrap rv-hero-grid">
     <div class="rv-hero-copy">
-      <p class="rv-eyebrow">River &middot; built on Freenet</p>
+      <div class="rv-brandmark">
+        <img class="rv-mark" src="{{ $logo }}" alt="" width="56" height="56">
+        <span class="rv-wordmark">River</span>
+        <span class="rv-brand-tag">built on Freenet</span>
+      </div>
       <h1 class="rv-h1">Group chat with <span class="rv-grad">no servers.</span></h1>
-      <p class="rv-sub">Encrypted group rooms that live on Freenet, a global peer-to-peer network, instead of anyone's servers. No company, no account, no phone number.</p>
+      <p class="rv-sub">River is group chat that lives on Freenet, a global peer-to-peer network, instead of anyone's servers. No company, no account, no phone number.</p>
       <div class="rv-cta-row">
         <a class="rv-btn rv-btn-invite" href="{{ "quickstart/" | relURL }}">Get an invite
           <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
@@ -16,9 +21,9 @@
         <a class="rv-btn rv-btn-ghost" href="#how">How it works</a>
       </div>
       <ul class="rv-reassure">
-        <li><span class="rv-tick">&#10003;</span> Runs in your browser</li>
-        <li><span class="rv-tick">&#10003;</span> End-to-end encrypted</li>
-        <li><span class="rv-tick">&#10003;</span> Open source</li>
+        <li><span class="rv-tick">{{ partial "inline/rv-check.html" . }}</span> Runs in your browser</li>
+        <li><span class="rv-tick">{{ partial "inline/rv-check.html" . }}</span> No account, no phone number</li>
+        <li><span class="rv-tick">{{ partial "inline/rv-check.html" . }}</span> Open source</li>
       </ul>
     </div>
     <div class="rv-hero-shot">
@@ -39,11 +44,12 @@
   </div>
 </header>
 
-<!-- ============ WAIT, NO SERVERS? (explainer) ============ -->
+<!-- ============ HOW IT WORKS (explainer) ============ -->
 <section class="rv-band" id="how">
   <div class="rv-wrap rv-whatis">
     <div>
-      <p class="rv-eyebrow">Wait, no servers?</p>
+      <p class="rv-eyebrow">How it works</p>
+      <h2 class="rv-h2">Wait, no servers?</h2>
       <p class="rv-lede">Most chat apps send your messages to <strong>servers a company runs</strong>. River sends them to <strong>Freenet</strong>, a network made of its users' own computers. Each room lives on the network itself, so it keeps working even if the person who made it goes offline, and nobody has a server to shut down, snoop on, or bill.</p>
     </div>
     <div class="rv-shapes">
@@ -70,7 +76,7 @@
 <!-- ===================== PILLARS ===================== -->
 <section class="rv-section">
   <div class="rv-wrap">
-    <div class="rv-head rv-center">
+    <div class="rv-head">
       <h2 class="rv-h2">Chat that no one owns</h2>
       <p class="rv-head-sub">The things that make River different are the things it leaves out.</p>
     </div>
@@ -98,10 +104,10 @@
       </div>
       <div class="rv-pillar">
         <span class="rv-ic">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2 4 14h7l-1 8 9-12h-7l1-8z"/></svg>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="6" cy="12" r="2.4"/><circle cx="17.5" cy="6" r="2.4"/><circle cx="17.5" cy="18" r="2.4"/><path d="M8.1 10.9 15.4 7.1M8.1 13.1 15.4 16.9"/></svg>
         </span>
         <h3 class="rv-pillar-t">Scales with demand</h3>
-        <p>A room in demand is cached on more peers, so it gets faster and more resilient as it grows, not slower. The opposite of the server model, where traffic is a bill.</p>
+        <p>The more people a room has, the more peers cache it, so it gets faster and sturdier as it grows, not slower. The opposite of the server model, where traffic is a bill.</p>
       </div>
     </div>
   </div>
@@ -112,64 +118,66 @@
   <div class="rv-wrap">
     <div class="rv-head rv-center">
       <p class="rv-eyebrow">Getting in</p>
-      <h2 class="rv-h2">There's nothing to download</h2>
-      <p class="rv-head-sub">River isn't an app you install from a store. You install Freenet once, then rooms open right in your browser from an invite link.</p>
+      <h2 class="rv-h2">You install Freenet, not River</h2>
+      <p class="rv-head-sub">River isn't a separate app to download. You install Freenet once, and any number of apps, River included, run on top of it and open right in your browser.</p>
     </div>
     <ol class="rv-steps">
       <li class="rv-step">
+        <span class="rv-step-n">1</span>
         <h3 class="rv-step-t">Install Freenet</h3>
-        <p>One small background app runs a Freenet peer on your machine. Everything River needs rides on top of it.</p>
+        <p>A small background app runs a Freenet peer on your machine. River and every other Freenet app run on top of it.</p>
       </li>
       <li class="rv-step">
+        <span class="rv-step-n">2</span>
         <h3 class="rv-step-t">Click an invite</h3>
-        <p>Get an invite to the official room, or from a friend. Rooms are invite-only, which is the membership model, not a paywall.</p>
+        <p>Get an invite to the official room, or from a friend. Rooms are invite-only, so you always know who let someone in.</p>
       </li>
       <li class="rv-step">
+        <span class="rv-step-n">3</span>
         <h3 class="rv-step-t">You're in the room</h3>
-        <p>River opens in your browser, on desktop or mobile. Create your own rooms and share their invite links the same way.</p>
+        <p>River opens in your browser. Create your own rooms and share their invite links the same way.</p>
       </li>
     </ol>
     <div class="rv-center rv-join-cta">
       <a class="rv-btn rv-btn-invite" href="{{ "quickstart/" | relURL }}">Install Freenet &amp; get an invite
         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
       </a>
-      <p class="rv-join-note">Prefer a terminal? River is fully scriptable with <code>riverctl</code>, handy for bots and AI agents. See the <a href="https://github.com/freenet/river/blob/main/cli/README.md">riverctl guide</a>.</p>
-    </div>
-  </div>
-</section>
-
-<!-- ===================== FEATURES ===================== -->
-<section class="rv-section">
-  <div class="rv-wrap">
-    <div class="rv-head">
-      <p class="rv-eyebrow">Features</p>
-      <h2 class="rv-h2">Everything you expect from a group chat</h2>
-    </div>
-    <div class="rv-features">
-      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Real-time group chat</b><span>Live rooms that sync across every member as messages arrive.</span></div></div>
-      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Public &amp; private rooms</b><span>Open rooms anyone with a link can join, or end-to-end encrypted private ones.</span></div></div>
-      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>One-click invite links</b><span>Share a link; it opens River and joins the recipient to the room.</span></div></div>
-      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Invitation-tree moderation</b><span>Manage or ban anyone you invited, or anyone downstream of them.</span></div></div>
-      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Desktop &amp; mobile</b><span>Runs in the browser on both, with no separate app to install.</span></div></div>
-      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Command-line client</b><span><code>riverctl</code> drives rooms from a script, bots and agents included.</span></div></div>
     </div>
   </div>
 </section>
 
 <!-- ============ WHY NOT ... (comparison) ============ -->
-<section class="rv-band">
+<section class="rv-section">
   <div class="rv-wrap">
     <div class="rv-head">
       <p class="rv-eyebrow">Why not Matrix, Discord, or Signal?</p>
-      <h2 class="rv-h2">They all keep a server somewhere</h2>
-      <p class="rv-head-sub">Other systems decentralize to different degrees, but each one still has a server that someone runs.</p>
+      <h2 class="rv-h2">Everyone else runs a server, or keeps you online</h2>
+      <p class="rv-head-sub">Other systems decentralize to different degrees, but each one still puts something between you and the room.</p>
     </div>
     <div class="rv-compare">
       <div class="rv-crow"><span class="rv-who">Discord, Signal</span><span class="rv-what">Central servers, operated by a company.</span></div>
       <div class="rv-crow"><span class="rv-who">Matrix</span><span class="rv-what">Federated homeservers, each one still run by someone.</span></div>
       <div class="rv-crow"><span class="rv-who">Nostr</span><span class="rv-what">Relays, which are servers.</span></div>
       <div class="rv-crow"><span class="rv-who">Briar, Tox</span><span class="rv-what">Serverless, but device-to-device: both people must be online, and there's no shared room the network keeps for you.</span></div>
-      <div class="rv-crow rv-crow-river"><span class="rv-who">River</span><span class="rv-what">Each room is state hosted by Freenet itself. No company server, no homeserver to pick, and rooms that persist when their creator is offline.</span></div>
+      <div class="rv-crow rv-crow-river"><span class="rv-who">River</span><span class="rv-what">Each room lives on Freenet itself. No company server, no homeserver to pick, and rooms that persist when their creator is offline.</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== FEATURES ===================== -->
+<section class="rv-band">
+  <div class="rv-wrap">
+    <div class="rv-head">
+      <p class="rv-eyebrow">Features</p>
+      <h2 class="rv-h2">The essentials, working today</h2>
+    </div>
+    <div class="rv-features">
+      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Real-time group chat</b><span>Live rooms that sync across every member as messages arrive.</span></div></div>
+      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Public &amp; private rooms</b><span>Public rooms anyone can read, or private rooms only members can decrypt.</span></div></div>
+      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>One-click invite links</b><span>Share a link; it opens River and joins the recipient to the room.</span></div></div>
+      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Invitation-tree moderation</b><span>Manage or ban anyone you invited, or anyone downstream of them.</span></div></div>
+      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Desktop &amp; mobile</b><span>Runs in the browser on both, with no separate app to install.</span></div></div>
+      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Command-line client</b><span><code>riverctl</code> drives rooms from a script, bots and agents included.</span></div></div>
     </div>
   </div>
 </section>
@@ -179,7 +187,7 @@
   <div class="rv-wrap">
     <div class="rv-head">
       <p class="rv-eyebrow">Privacy by design</p>
-      <h2 class="rv-h2">Nothing in the middle to leak</h2>
+      <h2 class="rv-h2">No middleman to leak</h2>
       <p class="rv-head-sub">Privacy in River isn't a mode you switch on. It's what's left when you remove the company, the account, and the server.</p>
     </div>
     <div class="rv-privacy">
@@ -188,20 +196,22 @@
       <div class="rv-pv"><span class="rv-pv-k">{{ partial "inline/rv-check.html" . }}</span><div><b>End-to-end encryption on private rooms.</b><span>Only members can read them, not the peers hosting the data.</span></div></div>
       <div class="rv-pv"><span class="rv-pv-k">{{ partial "inline/rv-check.html" . }}</span><div><b>Open source and auditable.</b><span>No blockchain, no token, no coins. Just code you can read on GitHub.</span></div></div>
     </div>
+    <p class="rv-privacy-note">Private rooms hide content, not shape: peers can still see that a room exists and roughly how active it is. If your threat model needs to hide that too, River alone isn't enough yet.</p>
   </div>
 </section>
 
 <!-- ===================== FINAL CTA ===================== -->
 <section class="rv-section rv-final">
   <div class="rv-wrap">
+    <p class="rv-alpha">River and Freenet are alpha: early software on an early network. Expect rough edges, and come tell us about them in the room.</p>
     <div class="rv-final-box">
-      <h2 class="rv-h2">See a decentralized network actually work</h2>
-      <p>Join the room where Freenet's developers and users hang out. It's the fastest way to watch peer-to-peer chat in action.</p>
+      <h2 class="rv-h2">The developers are in the room right now</h2>
+      <p>Join the official room where Freenet's developers and users hang out. It's the fastest way to see peer-to-peer chat working.</p>
       <div class="rv-final-cta">
         <a class="rv-btn rv-btn-oncolor" href="{{ "quickstart/" | relURL }}">Get an invite
           <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
         </a>
-        <a class="rv-btn rv-btn-ghost-oncolor" href="{{ "build/manual/" | relURL }}">Read the docs</a>
+        <a class="rv-btn rv-btn-ghost-oncolor" href="https://github.com/freenet/river">River on GitHub</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Problem

River has no page of its own on freenet.org. It is one section on `/apps/` (`#river`) that links out to the GitHub repo, so the effective landing page for River is a code README. The nav "River" entry just jumps to that anchor.

## Approach

A dedicated product landing page at **`freenet.org/river`**, structured like a modern messaging-app landing page (Signal / Session pattern) but adapted to River's reality: there is no app-store download, you install Freenet once and rooms open in the browser from an invite link. So the page swaps the usual "Download" row for a plain-language **"Wait, no servers?"** explainer plus a **"nothing to download, get an invite"** flow.

Design decisions (as discussed with Ian):

- **Top-level `/river`, not `/apps/river`** — matches the existing `/ghostkey` precedent of giving a flagship app its own top-level page, keeps a short shareable URL, and avoids restructuring the `/apps` catalog.
- **Keeps the site chrome** — standard Freenet dropdown nav and institutional footer are retained. River is a subpage, not a sub-brand, and the Freenet frame is the point (River exists to show off Freenet, and the first step to use it, Install/Quickstart, lives in that nav). Only `<main>` runs full-bleed, via a river-only `baseof`; the nav/footer stay in `.container` like every other page.
- **CSS scoped to `.river-page`** and kept in the river `baseof`, so it loads only on this page and never touches the shared `freenet.css`.
- **Copy adapted heavily from the River README** — the "no servers" pitch, the two-shapes explainer, the "why not Matrix/Discord/Signal?" comparison, the feature list, and the privacy model are all lifted from README language rather than invented.
- CTAs point to `/quickstart/` (install + live invite button) rather than embedding the invite button, since getting an invite only works after Freenet is installed.

Also repoints the `Apps > River` nav entry and the `/apps` catalog card at `/river/` (with an `/apps/river/` alias for safety).

## Testing

- `hugo --gc --minify` builds clean (117 pages, no errors/warnings).
- Rendered and screenshotted the real built page in **light + dark** (via `prefers-color-scheme`) and **desktop + mobile**; nav, full-bleed bands, dark-screenshot swap, responsive stacking, and the institutional footer all verified.

## Notes for review

- This is a **draft** pending Ian's sign-off on direction and copy. Content/tone is a design call; happy to adjust the headline ("no servers" vs the README's "no backend"), section order, or which features are surfaced.
- A Fable-5 review of style/layout/content is being run separately and its findings will be posted here.
- Follow-up (separate change): update the River repo `README.md` to focus on the developer/code audience and point users to this new landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRnnQnrtAVHdKzHKT8JrQ6

[AI-assisted - Claude]