### PR TITLE
feat(river): reviewer-driven polish (CTA, alpha box, discoverability)

### DIFF
--- a/hugo-site/content/_index.md
+++ b/hugo-site/content/_index.md
@@ -51,7 +51,8 @@ in just a few hops, scaling efficiently to millions of peers -- no servers requi
 ### For Users
 
 Freenet apps run in your browser and look like normal websites, but they can't be taken down,
-don't track you, and run peer-to-peer, not on the cloud.
+don't track you, and run peer-to-peer, not on the cloud. The easiest place to start is
+[River](/river/), decentralized group chat with no company in the middle.
 
 [Try it now →](/quickstart/)
 
@@ -85,6 +86,7 @@ decentralized internet infrastructure that matters.
 
 <div class="secondary-links">
 
+[River](/river/) ·
 [Apps](/apps/) ·
 [Video Talks](/about/video-talks/) ·
 [Matrix Chat](https://matrix.to/#/#freenet-locutus:matrix.org) ·

--- a/hugo-site/content/river/_index.md
+++ b/hugo-site/content/river/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "River: group chat with no servers"
-description: "River is encrypted group chat that runs on Freenet, a global peer-to-peer network, instead of anyone's servers. No company, no account, no phone number."
+title: "River: group chat with no company in the middle"
+description: "River is group chat that runs on Freenet, a global peer-to-peer network, instead of anyone's servers. No company, no account, no phone number."
 date: 2026-07-03
 draft: false
 aliases:

--- a/hugo-site/themes/freenet/layouts/river/baseof.html
+++ b/hugo-site/themes/freenet/layouts/river/baseof.html
@@ -61,7 +61,8 @@
     .rv-mark{ width:52px; height:52px; display:block; }
     .rv-wordmark{ font-family:var(--font-display); font-weight:700; font-size:2.2rem; letter-spacing:-.02em; color:var(--rv-ink); line-height:1; }
     .rv-brand-tag{ font-family:var(--font-display); font-weight:600; font-size:.7rem; letter-spacing:.1em; text-transform:uppercase; color:var(--rv-ink-faint); border:1px solid var(--rv-line); border-radius:999px; padding:.28rem .62rem; margin-left:.25rem; }
-    .rv-sub{ font-size:1.2rem; color:var(--rv-ink-soft); margin:1.1rem 0 1.7rem; max-width:36ch; }
+    .rv-sub{ font-size:1.2rem; color:var(--rv-ink-soft); margin:1.1rem 0 .9rem; max-width:36ch; }
+    .rv-hero-note{ font-size:1rem; color:var(--rv-ink-soft); margin:0 0 1.6rem; max-width:44ch; }
     .rv-cta-row{ display:flex; gap:.8rem; flex-wrap:wrap; align-items:center; }
     .rv-reassure{ list-style:none; padding:0; margin:1.2rem 0 0; display:flex; gap:1.1rem; flex-wrap:wrap; font-size:.92rem; color:var(--rv-ink-faint); }
     .rv-reassure li{ display:inline-flex; gap:.45rem; align-items:center; }
@@ -138,6 +139,19 @@
     .rv-pv span{ color:var(--rv-ink-soft); font-size:.96rem; display:block; margin-top:.1rem; }
     .rv-privacy-note{ margin:1.7rem 0 0; font-size:.95rem; color:var(--rv-ink-soft); max-width:74ch; }
     @media (max-width:700px){ .rv-privacy{ grid-template-columns:1fr; } }
+
+    /* where-river-is-today status box */
+    .rv-status{ display:grid; grid-template-columns:1fr 1fr; gap:1.2rem; }
+    .rv-status-col{ background:var(--rv-card); border:1px solid var(--rv-line); border-radius:14px; padding:1.4rem 1.5rem; box-shadow:var(--rv-shadow); }
+    .rv-status-t{ font-size:1.05rem; font-weight:600; margin:0 0 .8rem; display:flex; align-items:center; gap:.5rem; }
+    .rv-status-t svg{ flex:0 0 auto; }
+    .rv-status-good{ color:#0b6e33; }
+    .rv-status-alpha{ color:#b45309; }
+    @media (prefers-color-scheme: dark){ .rv-status-good{ color:#34d17f; } .rv-status-alpha{ color:#fbbf24; } }
+    .rv-status-col ul{ margin:0; padding-left:1.15rem; }
+    .rv-status-col li{ color:var(--rv-ink-soft); font-size:.96rem; margin:.4rem 0; line-height:1.45; }
+    .rv-status-col li::marker{ color:var(--rv-ink-faint); }
+    @media (max-width:700px){ .rv-status{ grid-template-columns:1fr; } }
 
     /* final */
     .rv-alpha{ text-align:center; max-width:62ch; margin:0 auto 1.6rem; font-size:.95rem; color:var(--rv-ink-faint); }

--- a/hugo-site/themes/freenet/layouts/river/list.html
+++ b/hugo-site/themes/freenet/layouts/river/list.html
@@ -14,8 +14,9 @@
       </div>
       <h1 class="rv-h1">Group chat with <span class="rv-grad">no company in the middle.</span></h1>
       <p class="rv-sub">River is group chat that lives on Freenet, a global peer-to-peer network, instead of anyone's servers. No company, no account, no phone number.</p>
+      <p class="rv-hero-note">Install a Freenet peer once, then join the live official room in your browser, where the developers hang out.</p>
       <div class="rv-cta-row">
-        <a class="rv-btn rv-btn-primary" href="{{ "quickstart/" | relURL }}">Try River
+        <a class="rv-btn rv-btn-primary" href="{{ "quickstart/" | relURL }}">Install Freenet &amp; Join River
           <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
         </a>
         <a class="rv-btn rv-btn-ghost" href="#how">How it works</a>
@@ -130,7 +131,7 @@
       <li class="rv-step">
         <span class="rv-step-n">2</span>
         <h3 class="rv-step-t">Click an invite</h3>
-        <p>Get an invite to the official room, or from a friend. Rooms are invite-only, so you always know who let someone in.</p>
+        <p>Grab a free invite to the official room, no friend needed, or use one a friend sent you. Rooms are invite-only, so you always know who let someone in.</p>
       </li>
       <li class="rv-step">
         <span class="rv-step-n">3</span>
@@ -139,7 +140,7 @@
       </li>
     </ol>
     <div class="rv-center rv-join-cta">
-      <a class="rv-btn rv-btn-primary" href="{{ "quickstart/" | relURL }}">Try River
+      <a class="rv-btn rv-btn-primary" href="{{ "quickstart/" | relURL }}">Install Freenet &amp; Join River
         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
       </a>
     </div>
@@ -155,7 +156,8 @@
       <p class="rv-head-sub">Other systems decentralize to different degrees, but each one still puts something between you and the room.</p>
     </div>
     <div class="rv-compare">
-      <div class="rv-crow"><span class="rv-who">Discord, Signal</span><span class="rv-what">Central servers, operated by a company.</span></div>
+      <div class="rv-crow"><span class="rv-who">Discord, Slack</span><span class="rv-what">Central servers a company runs, and can read.</span></div>
+      <div class="rv-crow"><span class="rv-who">Signal</span><span class="rv-what">Excellent end-to-end message encryption, but a company still runs the servers that host and relay, and it wants your phone number.</span></div>
       <div class="rv-crow"><span class="rv-who">Matrix</span><span class="rv-what">Federated homeservers, each one still run by someone.</span></div>
       <div class="rv-crow"><span class="rv-who">Nostr</span><span class="rv-what">Relays, which are servers.</span></div>
       <div class="rv-crow"><span class="rv-who">Briar, Tox</span><span class="rv-what">Serverless, but device-to-device: both people must be online, and there's no shared room the network keeps for you.</span></div>
@@ -169,13 +171,13 @@
   <div class="rv-wrap">
     <div class="rv-head">
       <p class="rv-eyebrow">Features</p>
-      <h2 class="rv-h2">The essentials, working today</h2>
+      <h2 class="rv-h2">The essentials</h2>
     </div>
     <div class="rv-features">
       <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Real-time group chat</b><span>Live rooms that sync across every member as messages arrive.</span></div></div>
       <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Public &amp; private rooms</b><span>Public rooms anyone can read, or private rooms only members can decrypt.</span></div></div>
       <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>One-click invite links</b><span>Share a link; it opens River and joins the recipient to the room.</span></div></div>
-      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Invitation-tree moderation</b><span>Manage or ban anyone you invited, or anyone downstream of them.</span></div></div>
+      <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Invitation-tree moderation</b><span>If someone you invited causes trouble, ban them and everyone they brought in, in one click.</span></div></div>
       <div class="rv-feat"><span class="rv-fic">{{ partial "inline/rv-check.html" . }}</span><div><b>Command-line client</b><span><code>riverctl</code> drives rooms from a script, bots and agents included.</span></div></div>
     </div>
   </div>
@@ -199,15 +201,53 @@
   </div>
 </section>
 
+<!-- ============ WHERE RIVER IS TODAY (alpha honesty) ============ -->
+<section class="rv-band">
+  <div class="rv-wrap">
+    <div class="rv-head">
+      <p class="rv-eyebrow">Straight talk</p>
+      <h2 class="rv-h2">Where River is today</h2>
+      <p class="rv-head-sub">River and Freenet are alpha. Here's what works now and what to expect, so nothing surprises you after you install.</p>
+    </div>
+    <div class="rv-status">
+      <div class="rv-status-col">
+        <h3 class="rv-status-t rv-status-good">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
+          Works today
+        </h3>
+        <ul>
+          <li>Join the live official room</li>
+          <li>Create your own rooms</li>
+          <li>Public rooms, and end-to-end encrypted private rooms</li>
+          <li>One-click invite links</li>
+          <li>Command-line client (<code>riverctl</code>)</li>
+        </ul>
+      </div>
+      <div class="rv-status-col">
+        <h3 class="rv-status-t rv-status-alpha">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/><path d="M12 9v4M12 17h.01"/></svg>
+          Still alpha
+        </h3>
+        <ul>
+          <li>Rough edges in the UI</li>
+          <li>Your Freenet peer sends diagnostic telemetry (peer activity, general system info) to help debug the network</li>
+          <li>Metadata isn't hidden: whether a room exists, its size, and message timing are observable</li>
+          <li>Not for sensitive communications yet</li>
+          <li>The network changes fast, and peers auto-update</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- ===================== FINAL CTA ===================== -->
 <section class="rv-section rv-final">
   <div class="rv-wrap">
-    <p class="rv-alpha">River and Freenet are alpha: early software on an early network. Expect rough edges, and come tell us about them in the room.</p>
     <div class="rv-final-box">
       <h2 class="rv-h2">The developers are in the room right now</h2>
       <p>Join the official room where Freenet's developers and users hang out. It's the fastest way to see peer-to-peer chat working.</p>
       <div class="rv-final-cta">
-        <a class="rv-btn rv-btn-oncolor" href="{{ "quickstart/" | relURL }}">Try River
+        <a class="rv-btn rv-btn-oncolor" href="{{ "quickstart/" | relURL }}">Install Freenet &amp; Join River
           <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
         </a>
         <a class="rv-btn rv-btn-ghost-oncolor" href="https://github.com/freenet/river">River on GitHub</a>


### PR DESCRIPTION
Follow-up to #62, applying two rounds of external review feedback on the live /river page.

## Changes
- **CTA:** `Try River` → **`Install Freenet & Join River`** on all three primary buttons. Two independent reviewers flagged that "Try River" hides the fact the next step installs Freenet. New wording is honest about the install without the "invite" gatekeeping tone we'd removed earlier. Also adds a hero line pulling the install expectation + "the developers are in the room" proof up near the top.
- **Alpha honesty:** new **"Where River is today"** box (Works today / Still alpha). Puts the diagnostic-telemetry disclosure, the metadata caveat, and "not for sensitive comms yet" on the landing page itself rather than only on quickstart. For a privacy audience, disclosing telemetry before the click is the honest move.
- **Signal comparison:** split the old "Discord, Signal" row so Signal gets credit for its message encryption, while keeping the architectural point (a company still runs its servers and wants a phone number). Avoids implying Signal reads messages.
- **"Invitation-tree moderation"** reworded from jargon into a plain-language benefit.
- **Join step 2** now reassures the official-room invite needs no friend (defuses "invite-only = I'm locked out").
- **Bug:** the `<title>`/`og:title` still said "group chat with no servers" after the H1 changed to "no company in the middle"; fixed. Dropped an "encrypted" overclaim from the meta description.
- **Homepage discoverability:** River is now linked from the "For Users" section and the secondary-links row. It was previously only reachable via the Apps nav dropdown.

## Deliberately not done
- **Property comparison table** (reviewer suggestion): kept the prose comparison per Ian; the reviewer's table also included a "persists if creator offline?" row that's a non-differentiator we'd already cut.
- **Better hero screenshot:** a crop of the current dense capture only gives marginal legibility; the real fix is a fresh narrow-viewport capture of River, which I'll do separately rather than ship a worse crop.

## Testing
`hugo --gc --minify` builds clean. Verified light/dark + desktop/mobile; the long CTA and the two-column status box both behave on mobile.

Draft pending review before deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRnnQnrtAVHdKzHKT8JrQ6

[AI-assisted - Claude]