### PR TITLE
feat(river): orient hero around Signal/WhatsApp familiarity; nonprofit trust strip

### DIFF
--- a/hugo-site/themes/freenet/layouts/river/baseof.html
+++ b/hugo-site/themes/freenet/layouts/river/baseof.html
@@ -36,6 +36,7 @@
     .rv-band{ padding:4rem 0; background:var(--rv-band); border-top:1px solid var(--rv-line); border-bottom:1px solid var(--rv-line); }
     .rv-eyebrow{ font-family:var(--font-display); font-weight:600; font-size:.8rem; letter-spacing:.13em; text-transform:uppercase; color:var(--rv-brand); margin:0 0 .7rem; }
     .rv-h1{ font-size:clamp(2.4rem,5vw,3.4rem); font-weight:700; line-height:1.06; margin:0; letter-spacing:-.02em; text-wrap:balance; }
+    .rv-h1-2{ font-size:.82em; }
     .rv-grad{ color:var(--rv-brand); }
     .rv-h2{ font-size:clamp(1.7rem,3.4vw,2.3rem); font-weight:700; margin:0; text-wrap:balance; }
     .rv-head{ margin-bottom:2.4rem; }
@@ -61,7 +62,8 @@
     .rv-mark{ width:52px; height:52px; display:block; }
     .rv-wordmark{ font-family:var(--font-display); font-weight:700; font-size:2.2rem; letter-spacing:-.02em; color:var(--rv-ink); line-height:1; }
     .rv-brand-tag{ font-family:var(--font-display); font-weight:600; font-size:.7rem; letter-spacing:.1em; text-transform:uppercase; color:var(--rv-ink-faint); border:1px solid var(--rv-line); border-radius:999px; padding:.28rem .62rem; margin-left:.25rem; }
-    .rv-sub{ font-size:1.2rem; color:var(--rv-ink-soft); margin:1.1rem 0 .9rem; max-width:36ch; }
+    .rv-sub{ font-size:1.2rem; color:var(--rv-ink-soft); margin:1.1rem 0 .7rem; max-width:44ch; }
+    .rv-punch{ font-family:var(--font-display); font-weight:600; font-size:1.08rem; color:var(--rv-ink); margin:.2rem 0 1.4rem; letter-spacing:-.01em; }
     .rv-hero-note{ font-size:1rem; color:var(--rv-ink-soft); margin:0 0 1.6rem; max-width:44ch; }
     .rv-cta-row{ display:flex; gap:.8rem; flex-wrap:wrap; align-items:center; }
     .rv-reassure{ list-style:none; padding:0; margin:1.2rem 0 0; display:flex; gap:1.1rem; flex-wrap:wrap; font-size:.92rem; color:var(--rv-ink-faint); }
@@ -155,6 +157,9 @@
 
     /* final */
     .rv-alpha{ text-align:center; max-width:62ch; margin:0 auto 1.6rem; font-size:.95rem; color:var(--rv-ink-faint); }
+    .rv-trust{ max-width:660px; margin:0 auto; text-align:center; background:var(--rv-card); border:1px solid var(--rv-line); border-radius:16px; padding:2.2rem 2rem; box-shadow:var(--rv-shadow); }
+    .rv-trust-t{ font-family:var(--font-display); font-size:1.3rem; font-weight:700; margin:0 0 .7rem; color:var(--rv-ink); }
+    .rv-trust-p{ color:var(--rv-ink-soft); margin:0; font-size:1.02rem; line-height:1.55; }
     .rv-final-box{ background:linear-gradient(135deg,#0066CC,#004C99); color:#fff; border-radius:20px; padding:3.2rem 2rem; box-shadow:var(--rv-shadow-l); text-align:center; }
     .rv-final-box .rv-h2{ color:#fff; }
     .rv-final-box p{ color:rgba(255,255,255,.9); max-width:46ch; margin:.9rem auto 1.7rem; }

--- a/hugo-site/themes/freenet/layouts/river/list.html
+++ b/hugo-site/themes/freenet/layouts/river/list.html
@@ -12,8 +12,9 @@
         <span class="rv-wordmark">River</span>
         <span class="rv-brand-tag">built on Freenet</span>
       </div>
-      <h1 class="rv-h1">Group chat with <span class="rv-grad">no company in the middle.</span></h1>
-      <p class="rv-sub">River is group chat that lives on Freenet, a global peer-to-peer network, instead of anyone's servers. No company, no account, no phone number.</p>
+      <h1 class="rv-h1">Group chat you already know.<br><span class="rv-grad rv-h1-2">Without the company in the middle.</span></h1>
+      <p class="rv-sub">River feels familiar, like Signal or WhatsApp. But it runs on Freenet, a global network nobody controls, with no servers behind it.</p>
+      <p class="rv-punch">No account. No phone number. No one in the middle. Just you.</p>
       <p class="rv-hero-note">Install a Freenet peer once, then join the live official room in your browser, where the developers hang out.</p>
       <div class="rv-cta-row">
         <a class="rv-btn rv-btn-primary" href="{{ "quickstart/" | relURL }}">Install Freenet &amp; Join River
@@ -23,7 +24,6 @@
       </div>
       <ul class="rv-reassure">
         <li><span class="rv-tick">{{ partial "inline/rv-check.html" . }}</span> Quick, easy install</li>
-        <li><span class="rv-tick">{{ partial "inline/rv-check.html" . }}</span> No account, no phone number</li>
         <li><span class="rv-tick">{{ partial "inline/rv-check.html" . }}</span> Free and open source</li>
       </ul>
     </div>
@@ -151,17 +151,16 @@
 <section class="rv-section">
   <div class="rv-wrap">
     <div class="rv-head">
-      <p class="rv-eyebrow">Why not Matrix, Discord, or Signal?</p>
-      <h2 class="rv-h2">Everyone else runs a server, or keeps you online</h2>
-      <p class="rv-head-sub">Other systems decentralize to different degrees, but each one still puts something between you and the room.</p>
+      <p class="rv-eyebrow">Why not Signal, WhatsApp, or Matrix?</p>
+      <h2 class="rv-h2">Everyone else runs on servers someone controls</h2>
+      <p class="rv-head-sub">Any single operator can be pressured, subpoenaed, breached, or decide to cut you off. It doesn't take bad intent, just one point everyone has to trust. River has none.</p>
     </div>
     <div class="rv-compare">
-      <div class="rv-crow"><span class="rv-who">Discord, Slack</span><span class="rv-what">Central servers a company runs, and can read.</span></div>
-      <div class="rv-crow"><span class="rv-who">Signal</span><span class="rv-what">Excellent end-to-end message encryption, but a company still runs the servers that host and relay, and it wants your phone number.</span></div>
-      <div class="rv-crow"><span class="rv-who">Matrix</span><span class="rv-what">Federated homeservers, each one still run by someone.</span></div>
-      <div class="rv-crow"><span class="rv-who">Nostr</span><span class="rv-what">Relays, which are servers.</span></div>
-      <div class="rv-crow"><span class="rv-who">Briar, Tox</span><span class="rv-what">Serverless, but device-to-device: both people must be online, and there's no shared room the network keeps for you.</span></div>
-      <div class="rv-crow rv-crow-river"><span class="rv-who">River</span><span class="rv-what">Each room lives on Freenet itself: the network keeps the room for you, with no company server and no homeserver to run.</span></div>
+      <div class="rv-crow"><span class="rv-who">WhatsApp</span><span class="rv-what">Encrypted, but it runs on Meta's servers and identifies you by your phone number.</span></div>
+      <div class="rv-crow"><span class="rv-who">Signal</span><span class="rv-what">Excellent encryption, run by a nonprofit. But it still runs on central servers, and needs a phone number to sign up.</span></div>
+      <div class="rv-crow"><span class="rv-who">Discord, Slack</span><span class="rv-what">A company's servers, which it can read.</span></div>
+      <div class="rv-crow"><span class="rv-who">Matrix</span><span class="rv-what">Homeservers, each with an admin in charge.</span></div>
+      <div class="rv-crow rv-crow-river"><span class="rv-who">River</span><span class="rv-what">Runs on Freenet, a network no one controls.</span></div>
     </div>
   </div>
 </section>
@@ -236,6 +235,16 @@
           <li>The network changes fast, and peers auto-update</li>
         </ul>
       </div>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== WHO BUILDS RIVER (nonprofit) ===================== -->
+<section class="rv-section">
+  <div class="rv-wrap">
+    <div class="rv-trust">
+      <h2 class="rv-trust-t">Built by a nonprofit, not an ad company</h2>
+      <p class="rv-trust-p">River and Freenet are built by Freenet Project Inc, a 501(c)(3) nonprofit. No ads, no investors, no business that runs on your data. Just open-source software that runs on a network its users own.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Problem

The /river landing page led with a "no company in the middle" contrast but didn't leverage the thing new users already know. Steven feedback: orient River in the *positive* category of global familiarity (Signal / WhatsApp) so newcomers have a mental anchor — without overclaiming encryption parity (Signal's double-ratchet forward/backward secrecy is real and River doesn't match it; claiming "privacy of Signal" would invite a pedantic nerd-debate and would be dishonest).

## Approach

Differentiate on **architecture and control**, never on encryption:

- **Hero** now leads with familiarity: "Group chat you already know. / Without the company in the middle." Subhead references Signal/WhatsApp, then pivots to Freenet ("a global network nobody controls"). New punch line: "No account. No phone number. No one in the middle. Just you." (The old "no account, no phone number" reassure tick was folded into the punch line.)
- **Comparison** reframed onto one honest axis — *everyone else runs on servers someone controls*. Names WhatsApp and Signal, credits their encryption, and stays fair to Signal (credited as a nonprofit — Signal Foundation is a 501(c)(3) — not "a company"). The section intro carries the structural argument ("any single operator can be pressured … it doesn't take bad intent, just one point everyone has to trust"), so the Signal row stays short and factual. Nostr and Briar/Tox rows dropped to keep the servers-control message clean.
- **Trust strip** added: "Built by a nonprofit, not an ad company" — Freenet Project Inc, a 501(c)(3). Framed on motive (no ads, no investors, no business that runs on your data), not on data-collection, to stay consistent with the page's alpha/telemetry disclosure.
- **CSS**: `.rv-h1-2` (smaller 2nd H1 line), `.rv-punch`, `.rv-trust*`; `.rv-sub` measure widened 36ch→44ch.

## Testing

- `hugo` build clean; rendered `/river/index.html` verified to contain all new copy and none of the replaced copy.
- Copy reviewed word-by-word by Ian, plus ChatGPT and Grok on earlier rounds.
- Review pass on this diff: Codex (external) — clean, no functional/build/maintainability issues. Adversarial Claude read — no BLOCKER/SHOULD-FIX; verified no orphan CSS classes, all `var()` tokens resolve, dark-mode tokens remapped, HTML/section nesting balanced, no overflow risk, template partials intact. Two copy NITs, both dismissed with justification (standard P2P "no servers" phrasing; deliberate no-encryption-parity design).

Copy-only change to two Hugo templates (HTML + scoped CSS). No logic, no wire format, no high-risk surface.

[AI-assisted - Claude]