### PR TITLE
feat(river): warn mobile visitors that Freenet is desktop-only

### DIFF
--- a/hugo-site/layouts/shortcodes/os-install.html
+++ b/hugo-site/layouts/shortcodes/os-install.html
@@ -101,6 +101,41 @@
     color: #004C99;
 }
 
+.os-mobile-notice {
+    display: none;
+    margin: 1.5rem 0;
+    padding: 1.25rem 1.4rem;
+    border: 1px solid #d1d5db;
+    border-left: 4px solid #0066CC;
+    background: rgba(0, 102, 204, 0.06);
+    border-radius: 8px;
+    font-size: 1rem;
+    line-height: 1.6;
+}
+
+.os-mobile-notice p {
+    margin: 0 0 0.85rem;
+}
+
+.os-mobile-notice strong {
+    color: #004C99;
+}
+
+.os-mobile-show {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    font-size: 0.92rem;
+    color: #0066CC;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.os-mobile-show:hover {
+    color: #004C99;
+}
+
 .os-install-tabs .download-btn svg {
     width: 1.25em;
     height: 1.25em;
@@ -132,6 +167,24 @@
 
     .os-install-tabs .install-note strong {
         color: #4da6ff;
+    }
+
+    .os-mobile-notice {
+        border-color: #374151;
+        border-left-color: #4da6ff;
+        background: rgba(77, 166, 255, 0.08);
+    }
+
+    .os-mobile-notice strong {
+        color: #4da6ff;
+    }
+
+    .os-mobile-show {
+        color: #4da6ff;
+    }
+
+    .os-mobile-show:hover {
+        color: #7cc0ff;
     }
 
     .os-install-tabs .download-btn {
@@ -196,6 +249,11 @@
     </div>
 </div>
 
+<div class="os-mobile-notice">
+    <p><strong>Freenet runs on a desktop computer.</strong> It installs on Windows, macOS, or Linux, then opens apps like River in your browser. Open this page on your computer to get started. A mobile app isn't available yet.</p>
+    <button type="button" class="os-mobile-show">On a computer? Show the install options.</button>
+</div>
+
 <script>
 (function() {
     function detectOS() {
@@ -212,6 +270,15 @@
         if (/Win/.test(platform)) return 'windows';
         if (/Mac/.test(platform) || /iPhone|iPad/.test(ua)) return 'mac';
         return 'linux';
+    }
+
+    function isMobile() {
+        var ua = navigator.userAgent || '';
+        if (/iPhone|iPod|Android|Mobile|Silk|Kindle|BlackBerry|Opera Mini|IEMobile/i.test(ua)) return true;
+        if (/iPad/i.test(ua)) return true;
+        // iPadOS 13+ reports as desktop Mac; catch it via touch support.
+        if (/Mac/i.test(navigator.platform || '') && navigator.maxTouchPoints > 1) return true;
+        return false;
     }
 
     function activateTab(os) {
@@ -233,6 +300,24 @@
         });
     });
 
-    activateTab(detectOS());
+    var tabsEl = document.querySelector('.os-install-tabs');
+    var noticeEl = document.querySelector('.os-mobile-notice');
+
+    if (isMobile() && tabsEl && noticeEl) {
+        // Phones and tablets can't run a desktop peer; show an honest notice
+        // instead of a desktop download button that does nothing on mobile.
+        tabsEl.style.display = 'none';
+        noticeEl.style.display = 'block';
+        var showBtn = noticeEl.querySelector('.os-mobile-show');
+        if (showBtn) {
+            showBtn.addEventListener('click', function() {
+                noticeEl.style.display = 'none';
+                tabsEl.style.display = '';
+                activateTab(detectOS());
+            });
+        }
+    } else {
+        activateTab(detectOS());
+    }
 })();
 </script>

--- a/hugo-site/themes/freenet/layouts/river/baseof.html
+++ b/hugo-site/themes/freenet/layouts/river/baseof.html
@@ -66,6 +66,8 @@
     .rv-punch{ font-family:var(--font-display); font-weight:600; font-size:1.08rem; color:var(--rv-ink); margin:.2rem 0 1.4rem; letter-spacing:-.01em; }
     .rv-hero-note{ font-size:1rem; color:var(--rv-ink-soft); margin:0 0 1.6rem; max-width:44ch; }
     .rv-cta-row{ display:flex; gap:.8rem; flex-wrap:wrap; align-items:center; }
+    .rv-platform{ display:inline-flex; align-items:center; gap:.42rem; font-size:.9rem; color:var(--rv-ink-faint); margin:1rem 0 .2rem; }
+    .rv-platform svg{ flex:0 0 auto; opacity:.85; }
     .rv-reassure{ list-style:none; padding:0; margin:1.2rem 0 0; display:flex; gap:1.1rem; flex-wrap:wrap; font-size:.92rem; color:var(--rv-ink-faint); }
     .rv-reassure li{ display:inline-flex; gap:.45rem; align-items:center; }
     .rv-tick{ color:var(--rv-brand); line-height:0; }

--- a/hugo-site/themes/freenet/layouts/river/list.html
+++ b/hugo-site/themes/freenet/layouts/river/list.html
@@ -22,6 +22,10 @@
         </a>
         <a class="rv-btn rv-btn-ghost" href="#how">How it works</a>
       </div>
+      <p class="rv-platform">
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+        Runs on Windows, macOS, and Linux. No mobile app yet.
+      </p>
       <ul class="rv-reassure">
         <li><span class="rv-tick">{{ partial "inline/rv-check.html" . }}</span> Quick, easy install</li>
         <li><span class="rv-tick">{{ partial "inline/rv-check.html" . }}</span> Free and open source</li>
@@ -228,6 +232,7 @@
           Still alpha
         </h3>
         <ul>
+          <li>Desktop only (Windows, macOS, Linux); no mobile app yet</li>
           <li>Rough edges in the UI</li>
           <li>Your Freenet peer sends diagnostic telemetry (peer activity, general system info) to help debug the network</li>
           <li>Metadata isn't hidden: whether a room exists, its size, and message timing are observable</li>


### PR DESCRIPTION
## Problem

A mobile visitor could land on /river, tap **Install Freenet & Join River**, and hit a dead end. Nothing on either page said Freenet is desktop-only, and the `/quickstart` installer made it worse: its `os-install` shortcode auto-selects an OS tab by device and maps **iPhone/iPad → the macOS download** and **Android → the Linux install** — so a phone user was shown a desktop download button that does nothing.

## Approach

Be upfront on the landing page, and stop the installer from handing mobile users a broken download.

- **/river hero** — a platform line under the CTA, visible to everyone (so mobile users see it *before* tapping): *"Runs on Windows, macOS, and Linux. No mobile app yet."*
- **/river "Where River is today" alpha box** — an honest bullet: *"Desktop only (Windows, macOS, Linux); no mobile app yet"*.
- **/quickstart `os-install` shortcode** — detect phones/tablets (including iPadOS 13+, which masquerades as desktop Mac, via `maxTouchPoints`) and replace the bogus desktop download with a clear notice: open the page on a computer, no mobile app yet. Includes an *"On a computer? Show the install options"* safety valve in case a desktop is misdetected. **Desktop behavior is unchanged** (`detectOS` / `activateTab` / tab handlers are byte-for-byte identical; the only removed line, `activateTab(detectOS())`, is preserved verbatim in the new `else` branch).

Phrased as "no mobile app **yet**" — honest about the current state without promising a timeline.

## Testing

Verified end-to-end with Playwright:
- **iPhone `/quickstart`**: desktop tabs hidden (`display:none`), honest notice shown; the safety-valve button restores the tabs and re-runs detection.
- **iPhone `/river`**: platform line renders under the CTA with the correct text.
- **Desktop `/quickstart` (control)**: tabs visible, notice hidden, correct OS tab auto-selected — unchanged from before.

Hugo build clean; no em-dashes.

## Review

- **Codex (external):** clean — no functional regressions or discrete bugs.
- **Adversarial read:** clean — no false positives for Windows-touch laptops / Surface / MacBooks (the Mac+touch branch is gated on `navigator.platform`, and real Macs report `maxTouchPoints === 0`); `isMobile()` can't throw; safety valve verified. Three edge-case NITs (keyboard focus after the safety-valve click; a brief pre-hide tab flash; no-JS mobile falls back to the Linux default — pre-existing), all dismissed as not worth blocking.

Copy-only + progressive-enhancement JS; no high-risk surface.

[AI-assisted - Claude]