### PR TITLE
feat(river): simplify hero headline to "Group chat without the company in the middle"

### DIFF
--- a/hugo-site/themes/freenet/layouts/river/baseof.html
+++ b/hugo-site/themes/freenet/layouts/river/baseof.html
@@ -36,7 +36,6 @@
     .rv-band{ padding:4rem 0; background:var(--rv-band); border-top:1px solid var(--rv-line); border-bottom:1px solid var(--rv-line); }
     .rv-eyebrow{ font-family:var(--font-display); font-weight:600; font-size:.8rem; letter-spacing:.13em; text-transform:uppercase; color:var(--rv-brand); margin:0 0 .7rem; }
     .rv-h1{ font-size:clamp(2.4rem,5vw,3.4rem); font-weight:700; line-height:1.06; margin:0; letter-spacing:-.02em; text-wrap:balance; }
-    .rv-h1-2{ font-size:.82em; }
     .rv-grad{ color:var(--rv-brand); }
     .rv-h2{ font-size:clamp(1.7rem,3.4vw,2.3rem); font-weight:700; margin:0; text-wrap:balance; }
     .rv-head{ margin-bottom:2.4rem; }

--- a/hugo-site/themes/freenet/layouts/river/list.html
+++ b/hugo-site/themes/freenet/layouts/river/list.html
@@ -12,7 +12,7 @@
         <span class="rv-wordmark">River</span>
         <span class="rv-brand-tag">built on Freenet</span>
       </div>
-      <h1 class="rv-h1">Group chat you already know.<br><span class="rv-grad rv-h1-2">Without the company in the middle.</span></h1>
+      <h1 class="rv-h1">Group chat <span class="rv-grad">without the company in the middle.</span></h1>
       <p class="rv-sub">River feels familiar, like Signal or WhatsApp. But it runs on Freenet, a global network nobody controls, with no servers behind it.</p>
       <p class="rv-punch">No account. No phone number. No one in the middle. Just you.</p>
       <p class="rv-hero-note">Install a Freenet peer once, then join the live official room in your browser, where the developers hang out.</p>


### PR DESCRIPTION
## Problem

The hero H1 "Group chat you already know. / Without the company in the middle." leads with a familiarity claim that reads as slick, 1960s-ad-style marketing and presumes what the reader already knows.

## Approach

Lead the headline with the differentiator: **"Group chat without the company in the middle."** (the last phrase in brand blue). The Signal/WhatsApp familiarity that "you already know" was reaching for is still carried by the subhead directly below ("River feels familiar, like Signal or WhatsApp…"), so the orientation is preserved, just moved a line down. Also removes the now-unused `.rv-h1-2` CSS rule.

## Testing

Hugo build clean; verified the new H1 renders (desktop + iPhone) with correct dark/blue split, and the old copy and dead class are gone. Copy-only change to one template + one dead CSS rule; no logic.

Wording chosen by Ian.

[AI-assisted - Claude]