### PR TITLE
fix(river): tighten "no servers" diagram cards; drop "Rough edges" alpha bullet

### DIFF
--- a/hugo-site/themes/freenet/layouts/river/baseof.html
+++ b/hugo-site/themes/freenet/layouts/river/baseof.html
@@ -88,7 +88,7 @@
     .rv-lede{ font-size:1.25rem; line-height:1.5; color:var(--rv-ink); margin:0; }
     .rv-lede strong{ color:var(--rv-brand); }
     .rv-shapes{ display:grid; gap:.9rem; }
-    .rv-shape{ background:var(--rv-card); border:1px solid var(--rv-line); border-radius:12px; padding:1rem 1.15rem; box-shadow:var(--rv-shadow); }
+    .rv-shape{ background:var(--rv-card); border:1px solid var(--rv-line); border-radius:12px; padding:1rem 1.15rem; box-shadow:var(--rv-shadow); width:fit-content; max-width:100%; }
     .rv-shape-lbl{ font-family:var(--font-display); font-size:.72rem; letter-spacing:.1em; text-transform:uppercase; color:var(--rv-ink-faint); }
     .rv-flow{ display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; margin-top:.45rem; }
     .rv-chip{ font-family:var(--font-display); background:var(--rv-brand-soft); color:var(--rv-brand); border-radius:7px; padding:.15rem .6rem; font-size:.86rem; font-weight:600; }

--- a/hugo-site/themes/freenet/layouts/river/list.html
+++ b/hugo-site/themes/freenet/layouts/river/list.html
@@ -233,7 +233,6 @@
         </h3>
         <ul>
           <li>Desktop only (Windows, macOS, Linux); no mobile app yet</li>
-          <li>Rough edges in the UI</li>
           <li>Your Freenet peer sends diagnostic telemetry (peer activity, general system info) to help debug the network</li>
           <li>Metadata isn't hidden: whether a room exists, its size, and message timing are observable</li>
           <li>Not for sensitive communications yet</li>


### PR DESCRIPTION
## Problem

Two small landing-page fixes:
1. In the "Wait, no servers?" diagram, the "A normal chat app" and "River" cards were stretched to the full grid-column width while their chip rows were left-aligned, so each card had empty space on the right (most noticeable on the shorter River card). Looked broken.
2. The "Still alpha" box had a vague "Rough edges in the UI" bullet.

## Approach

1. Give `.rv-shape` `width:fit-content; max-width:100%` so each card hugs its flow content instead of stretching. Dead space gone; the two cards' right edges now line up (~460px each on desktop), and it subtly shows River's path is shorter. `max-width:100%` keeps the mobile behavior (cards go full-width and content wraps) unchanged.
2. Remove the "Rough edges in the UI" alpha bullet.

## Testing

Hugo build clean. Verified the diagram at desktop (1280px) and iPhone widths via Playwright screenshots: no right-side gap on desktop, content wraps cleanly on mobile. Confirmed the bullet is gone and the rest of the alpha box is intact.

CSS + one-line copy removal; no logic.

[AI-assisted - Claude]