### PR TITLE
style(home): side-by-side hero CTA; move hosted-demo framing to /try/

### DIFF
--- a/hugo-site/content/_index.md
+++ b/hugo-site/content/_index.md
@@ -21,7 +21,7 @@ are unstoppable, interoperable, and built on open protocols.
 ## How Freenet Works
 
 Peers form a small-world network organized by location on a ring. Messages find their destination
-in just a few hops, scaling efficiently to millions of peers -- no servers required.
+in just a few hops, scaling efficiently to millions of peers, no servers required.
 
 {{< network-hero alt="Freenet peer-to-peer network visualization" >}}
 

--- a/hugo-site/content/_index.md
+++ b/hugo-site/content/_index.md
@@ -9,11 +9,9 @@ Freenet is a peer-to-peer platform for decentralized applications: communication
 commerce without reliance on big tech. Your computer becomes part of a global network where apps
 are unstoppable, interoperable, and built on open protocols.
 
-<a href="/quickstart/" class="cta-button">Install Freenet</a>
-
-<div class="cta-secondary-wrap">
+<div class="cta-row">
+  <a href="/quickstart/" class="cta-button">Install Freenet</a>
   <a href="/try/" class="cta-secondary">Or try it in your browser first →</a>
-  <span class="cta-note">A hosted demo so you can try Freenet without installing. It runs on our server, not the network, so when you're ready, run your own peer and keep using the same rooms on the real network.</span>
 </div>
 
 <div class="action-and-news">

--- a/hugo-site/content/try/_index.md
+++ b/hugo-site/content/try/_index.md
@@ -8,11 +8,9 @@ Try Freenet right now, no install. This opens **River**, a group chat app that r
 peer-to-peer Freenet contract, and drops you into the live **Freenet Official** room where the
 project's developers and users talk. No account, no download.
 
-{{< alert type="warning" >}} **This is a hosted demo.** It runs on our server, not the
-decentralized network, so you can try Freenet without installing anything. It's a taste, not the
-real thing: the whole point of Freenet is that apps run peer-to-peer on *your* computer, with no
-company in the middle. When you're ready, [install your own peer](/quickstart/) and keep using the same
-rooms on the real network. {{< /alert >}}
+{{< alert type="warning" >}} **This is a hosted demo.** It runs on our server, so your data lives
+with us, not on your own machine. [Install your own peer](/quickstart/) anytime and export your data
+to it in one click. {{< /alert >}}
 
 {{< river-invite-button room="Freenet Official" base="https://try.freenet.org/v1/contract/web/raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv/" hosted="true" >}}
 

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -135,10 +135,20 @@
     margin-bottom: 0.9rem;
 }
 
+/* Hero action row: the Install button and the secondary "try" link side by side,
+   vertically centered, wrapping to stacked on narrow screens. */
+.cta-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.5rem;
+    margin: 1.75rem 0 3.5rem 0;
+}
+
 /* Primary CTA button */
 .cta-button {
     display: inline-block;
-    margin: 1.75rem 0 0 0;
+    margin: 0;
     background: linear-gradient(135deg, #0066CC 0%, #004C99 100%);
     color: #ffffff !important;
     border: none;
@@ -160,11 +170,6 @@
 /* Secondary CTA: the hosted-demo "try in your browser" entry. Kept visually
    subordinate to the primary Install button so the real (self-hosted) path
    stays front and center. */
-.cta-secondary-wrap {
-    margin: 1rem 0 3.5rem 0;
-    max-width: 620px;
-}
-
 .cta-secondary {
     display: inline-block;
     font-family: var(--font-display);
@@ -177,22 +182,11 @@
     text-decoration: underline;
 }
 
-.cta-note {
-    display: block;
-    margin-top: 0.4rem;
-    font-size: 0.9rem;
-    line-height: 1.45;
-    color: #64748b;
-}
-
-/* Dark mode: match the site's existing link (#4da6ff) and muted-text (#94a3b8)
-   dark overrides so the new hero links aren't dim / low-contrast. */
+/* Dark mode: match the site's existing bright link color so the hero "try" link
+   isn't dim / low-contrast. */
 @media (prefers-color-scheme: dark) {
     .cta-secondary {
         color: #4da6ff;
-    }
-    .cta-note {
-        color: #94a3b8;
     }
 }
 

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -128,9 +128,8 @@
     font-size: 0.9rem;
 }
 
-/* Hero spacing: group the pitch (headline + paragraph) tightly, then a clear
-   gap to the action group (button + try link + note), which is itself tight.
-   Even gaps made it unclear what grouped with what (the button floated). */
+/* Hero spacing: tight gap under the headline, then the action row (button + try
+   link) sits below with a clear separation. */
 .home > h1.title {
     margin-bottom: 0.9rem;
 }


### PR DESCRIPTION
DRAFT until review passes (merge auto-deploys freenet.org).

## Problem
Follow-up polish on the try.freenet.org discoverability hero (#68): the stacked layout + inline note made the hero text-heavy, the note ambiguously applied to both CTAs, and the /try/ callout said "a taste, not the real thing" which begs questions instead of explaining.

## Approach
- **Hero**: Install button + "Or try it in your browser first" link side by side, vertically centered, wrapping to stacked on mobile. Dropped the inline note.
- **/try/**: the hosted-demo framing lives here now, rewritten in plain language (state the actual difference: your data is on our server vs your own machine) with the one-click export-to-your-peer hook.

## Backing
The one-click hosted->local migration (freenet-core #4592) is verified end-to-end (imported:6 real River secrets to a fresh local peer, durable + non-destructive), so "export your data to it in one click" is an honest claim.

## Testing
Rendered locally; verified desktop side-by-side (link vertically centered on the button, 0px offset) + mobile stack, no em-dashes, no stale copy. Copy + CSS only, no JS/logic change.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jmCd1tvDH1EsVTtaDVnxJ