### PR TITLE
docs(try): note hosted data is encrypted with the user's access key

### DIFF
--- a/hugo-site/content/try/_index.md
+++ b/hugo-site/content/try/_index.md
@@ -9,8 +9,8 @@ peer-to-peer Freenet contract, and drops you into the live **Freenet Official** 
 project's developers and users talk. No account, no download.
 
 {{< alert type="warning" >}} **This is a hosted demo.** It runs on our server, so your data lives
-with us, not on your own machine. [Install your own peer](/quickstart/) anytime and export your data
-to it in one click. {{< /alert >}}
+with us. It's encrypted with your access key, so while you're not using it even we can't read it.
+[Install your own peer](/quickstart/) anytime and export your data to it in one click. {{< /alert >}}
 
 {{< river-invite-button room="Freenet Official" base="https://try.freenet.org/v1/contract/web/raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv/" hosted="true" >}}
 


### PR DESCRIPTION
DRAFT until review passes (merge auto-deploys freenet.org).

## Problem
The /try/ callout says "your data lives with us" but omits a real, reassuring fact: hosted per-user data is encrypted at rest with a key derived SOLELY from the user access token, so the operator cannot read it when the user is not actively connected.

## Approach
One added sentence in the callout: "It's encrypted with your access key, so while you're not using it even we can't read it."

## Backing (verified, not assumed)
Confirmed against `freenet-core crates/core/src/server/client_api/hosted_export.rs` ("Threat model: the token is the entire secret"): the per-user DEK and bundle key are derived solely from the user token and are node-KEK-independent by design; there is no node-side second factor. The token is header-only, zeroized, and lives in the user's browser. Honest nuance: while the user IS actively connected the node holds the token and can decrypt to run the app; the claim is scoped to data at rest ("while you're not using it"), which the wording states.

## Testing
Rendered locally; callout reads correctly, no em/en-dashes. Copy-only change.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jmCd1tvDH1EsVTtaDVnxJ