### PR TITLE
fix: reduce invite API per-IP rate limit to 4/24h and key on socket peer IP

### DIFF
--- a/rust/api/src/rate_limit.rs
+++ b/rust/api/src/rate_limit.rs
@@ -12,8 +12,13 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 use thiserror::Error;
 
-/// Maximum number of invites allowed per IP within the time window
-const MAX_INVITES_PER_WINDOW: usize = 20;
+/// Maximum number of invites allowed per IP within the time window.
+///
+/// Kept deliberately low as an anti-spam measure for the freenet.org/quickstart
+/// flow, which mints invites into the shared "Freenet Official" room. Raising
+/// this without a matching anti-abuse story re-opens the bulk-account-creation
+/// vector this limit exists to slow. See `test_rate_limiter_enforces_two_per_window`.
+const MAX_INVITES_PER_WINDOW: usize = 2;
 
 /// SHA256 hashes of IPs exempt from rate limiting (for testing)
 const EXEMPT_IP_HASHES: &[&str] = &[
@@ -177,6 +182,32 @@ mod tests {
 
         let ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
         assert!(limiter.check_and_record(ip).unwrap());
+    }
+
+    /// Pins the deployed anti-spam limit at exactly 2 invites / IP / window.
+    ///
+    /// The other tests are parameterized on `MAX_INVITES_PER_WINDOW`, so they
+    /// pass at any value and would NOT catch an accidental bump of the
+    /// constant. This one hardcodes the intended value: a 3rd invite from the
+    /// same IP inside the window must be rejected.
+    #[test]
+    fn test_rate_limiter_enforces_two_per_window() {
+        assert_eq!(
+            MAX_INVITES_PER_WINDOW, 2,
+            "invite anti-spam limit must stay at 2/IP/window; raising it re-opens bulk account creation"
+        );
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("rate_limits.json");
+        let limiter = RateLimiter::new(path, 24);
+
+        let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7));
+        assert!(limiter.check_and_record(ip).unwrap(), "1st invite allowed");
+        assert!(limiter.check_and_record(ip).unwrap(), "2nd invite allowed");
+        assert!(
+            !limiter.check_and_record(ip).unwrap(),
+            "3rd invite in window must be rejected"
+        );
     }
 
     #[test]

--- a/rust/api/src/rate_limit.rs
+++ b/rust/api/src/rate_limit.rs
@@ -15,10 +15,12 @@ use thiserror::Error;
 /// Maximum number of invites allowed per IP within the time window.
 ///
 /// Kept deliberately low as an anti-spam measure for the freenet.org/quickstart
-/// flow, which mints invites into the shared "Freenet Official" room. Raising
-/// this without a matching anti-abuse story re-opens the bulk-account-creation
-/// vector this limit exists to slow. See `test_rate_limiter_enforces_two_per_window`.
-const MAX_INVITES_PER_WINDOW: usize = 2;
+/// flow, which mints invites into the shared "Freenet Official" room. A few
+/// invites per day covers legitimate re-invites while still slowing bulk
+/// account creation. Raising this without a matching anti-abuse story re-opens
+/// the vector this limit exists to slow. See
+/// `test_rate_limiter_enforces_four_per_window`.
+const MAX_INVITES_PER_WINDOW: usize = 4;
 
 /// SHA256 hashes of IPs exempt from rate limiting (for testing)
 const EXEMPT_IP_HASHES: &[&str] = &[
@@ -184,17 +186,17 @@ mod tests {
         assert!(limiter.check_and_record(ip).unwrap());
     }
 
-    /// Pins the deployed anti-spam limit at exactly 2 invites / IP / window.
+    /// Pins the deployed anti-spam limit at exactly 4 invites / IP / window.
     ///
     /// The other tests are parameterized on `MAX_INVITES_PER_WINDOW`, so they
     /// pass at any value and would NOT catch an accidental bump of the
-    /// constant. This one hardcodes the intended value: a 3rd invite from the
+    /// constant. This one hardcodes the intended value: the 5th invite from the
     /// same IP inside the window must be rejected.
     #[test]
-    fn test_rate_limiter_enforces_two_per_window() {
+    fn test_rate_limiter_enforces_four_per_window() {
         assert_eq!(
-            MAX_INVITES_PER_WINDOW, 2,
-            "invite anti-spam limit must stay at 2/IP/window; raising it re-opens bulk account creation"
+            MAX_INVITES_PER_WINDOW, 4,
+            "invite anti-spam limit must stay at 4/IP/window; raising it re-opens bulk account creation"
         );
 
         let dir = tempdir().unwrap();
@@ -202,11 +204,15 @@ mod tests {
         let limiter = RateLimiter::new(path, 24);
 
         let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7));
-        assert!(limiter.check_and_record(ip).unwrap(), "1st invite allowed");
-        assert!(limiter.check_and_record(ip).unwrap(), "2nd invite allowed");
+        for i in 1..=4 {
+            assert!(
+                limiter.check_and_record(ip).unwrap(),
+                "invite {i} of 4 should be allowed"
+            );
+        }
         assert!(
             !limiter.check_and_record(ip).unwrap(),
-            "3rd invite in window must be rejected"
+            "5th invite in window must be rejected"
         );
     }
 

--- a/rust/api/src/routes.rs
+++ b/rust/api/src/routes.rs
@@ -396,7 +396,7 @@ async fn create_room_invite(
             return Err((
                 StatusCode::TOO_MANY_REQUESTS,
                 Json(InviteErrorResponse {
-                    error: "Rate limited. You can request up to 20 invites per 24 hours."
+                    error: "Rate limited. You can request up to 2 invites per 24 hours."
                         .to_string(),
                     retry_after_seconds: retry_after,
                 }),

--- a/rust/api/src/routes.rs
+++ b/rust/api/src/routes.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use axum::{
     extract::{ConnectInfo, Path, State},
-    http::{HeaderMap, StatusCode},
+    http::StatusCode,
     response::{IntoResponse, Json},
     routing::{get, post},
     Router,
@@ -346,39 +346,28 @@ pub struct InviteErrorResponse {
     pub retry_after_seconds: Option<i64>,
 }
 
-/// Extract client IP from request, handling X-Forwarded-For header for proxies
-fn get_client_ip(headers: &HeaderMap, addr: SocketAddr) -> IpAddr {
-    // Check X-Forwarded-For header (set by reverse proxies)
-    if let Some(xff) = headers.get("x-forwarded-for") {
-        if let Ok(xff_str) = xff.to_str() {
-            // Take the first IP (original client)
-            if let Some(first_ip) = xff_str.split(',').next() {
-                if let Ok(ip) = first_ip.trim().parse::<IpAddr>() {
-                    return ip;
-                }
-            }
-        }
-    }
-
-    // Check X-Real-IP header (alternative proxy header)
-    if let Some(real_ip) = headers.get("x-real-ip") {
-        if let Ok(ip_str) = real_ip.to_str() {
-            if let Ok(ip) = ip_str.trim().parse::<IpAddr>() {
-                return ip;
-            }
-        }
-    }
-
-    // Fall back to connection address
+/// Extract the client IP used to key the invite rate limiter.
+///
+/// We deliberately key on the TCP connection's peer address (`addr.ip()`) and
+/// do NOT trust `X-Forwarded-For` / `X-Real-IP`. gkapi is directly
+/// internet-facing (it binds :80/:443 and terminates its own TLS; there is no
+/// reverse proxy in front), so those headers are fully client-controlled and
+/// trusting them would let a spammer bypass the limit by rotating a spoofed
+/// header. `addr.ip()` returns the bare `IpAddr` (no port), so both IPv4 and
+/// IPv6 peers key correctly.
+///
+/// If a trusted reverse proxy / Cloudflare is ever placed in front of gkapi,
+/// revisit HERE to trust `X-Forwarded-For` ONLY when the peer is that proxy's
+/// IP. Do not re-add blanket `X-Forwarded-For` trust.
+fn get_client_ip(addr: SocketAddr) -> IpAddr {
     addr.ip()
 }
 
 async fn create_room_invite(
     State(state): State<InviteState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
-    headers: HeaderMap,
 ) -> Result<Json<CreateInviteResponse>, (StatusCode, Json<InviteErrorResponse>)> {
-    let client_ip = get_client_ip(&headers, addr);
+    let client_ip = get_client_ip(addr);
     info!("Received create-invite request from IP: {}", client_ip);
 
     // Check rate limit
@@ -396,7 +385,7 @@ async fn create_room_invite(
             return Err((
                 StatusCode::TOO_MANY_REQUESTS,
                 Json(InviteErrorResponse {
-                    error: "Rate limited. You can request up to 2 invites per 24 hours."
+                    error: "Rate limited. You can request up to 4 invites per 24 hours."
                         .to_string(),
                     retry_after_seconds: retry_after,
                 }),


### PR DESCRIPTION
## Problem

The `freenet.org/quickstart` flow mints River invitations into the shared
**Freenet Official** room via gkapi's `POST https://gkapi.freenet.org/create-invite`.
The room is being spammed via bulk invite generation. Two issues made this easy:

1. The per-IP limit was **20 invites / 24h** — too loose.
2. The limiter keyed on `X-Forwarded-For` first. gkapi is **directly
   internet-facing** (binds `0.0.0.0:80`/`:443`, terminates its own Let's
   Encrypt TLS, no reverse proxy; `gkapi.freenet.org` resolves straight to the
   host). With no trusted proxy in front, `X-Forwarded-For` is fully
   client-controlled, so the limit was bypassable at **any** threshold by
   rotating a spoofed header.

## Approach

- **Limit 20 → 4 per IP per rolling 24h window.** `MAX_INVITES_PER_WINDOW = 4`
  in `rust/api/src/rate_limit.rs`; 24h window unchanged. 4 covers legitimate
  re-invites while still slowing bulk creation. The 429 message is updated to
  match.
- **Key the rate limiter on the socket peer IP, not `X-Forwarded-For`.**
  `get_client_ip` now returns `addr.ip()` from `ConnectInfo<SocketAddr>` (already
  wired via `into_make_service_with_connect_info::<SocketAddr>()` in `main.rs`)
  and no longer trusts `X-Forwarded-For` / `X-Real-IP`. `addr.ip()` is the bare
  `IpAddr` (no port), so IPv4/IPv6 peers key correctly. A comment marks the spot
  to revisit **only** if a trusted reverse proxy / Cloudflare is ever added (trust
  XFF from that proxy's IP only — never blanket XFF trust again).
- Added `test_rate_limiter_enforces_four_per_window`, which **hardcodes** the
  intended value (`4`) and asserts the 5th invite from an IP is rejected. The
  pre-existing rate-limit tests are parameterized on the constant and would not
  catch an accidental bump (history shows it drifting `5 -> 20`). Runs in CI via
  `cargo make integration-test` (`cd rust/api && cargo test`).

## Testing

`cargo test` in `rust/api` — all 5 `rate_limit::tests` pass, including the new one.

## Notes

- gkapi binds `0.0.0.0` (IPv4-only) today, so peers are IPv4 in practice; the
  bare-`IpAddr` keying is still correct if IPv6 binding is ever added.
- Live deploy is a rebuild-from-`main` on the host (`update-from-github.fish`);
  it only takes effect after this merges to main.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B49wBfvR8EjpfYTw5muNV9