### PR TITLE
fix(presentations): slow slide-5 ecosystem orbit to 60s/rev

### DIFF
--- a/hugo-site/static/slides/futo/since-last-time-sphere.html
+++ b/hugo-site/static/slides/futo/since-last-time-sphere.html
@@ -283,10 +283,10 @@
     }
 
     /* --- slow counter-rotating orbits (~30s/rev), core stays put --- */
-    .sphere-slide .orbit-cw   { animation: sphOrbitCW  30s linear infinite; }
-    .sphere-slide .orbit-ccw  { animation: sphOrbitCCW 30s linear infinite; }
-    .sphere-slide .octr-cw    { animation: sphOrbitCW  30s linear infinite; }  /* counters an CCW ring */
-    .sphere-slide .octr-ccw   { animation: sphOrbitCCW 30s linear infinite; }  /* counters a  CW  ring */
+    .sphere-slide .orbit-cw   { animation: sphOrbitCW  60s linear infinite; }
+    .sphere-slide .orbit-ccw  { animation: sphOrbitCCW 60s linear infinite; }
+    .sphere-slide .octr-cw    { animation: sphOrbitCW  60s linear infinite; }  /* counters an CCW ring */
+    .sphere-slide .octr-ccw   { animation: sphOrbitCCW 60s linear infinite; }  /* counters a  CW  ring */
     @keyframes sphOrbitCW  { to { transform: rotate(360deg); } }
     @keyframes sphOrbitCCW { to { transform: rotate(-360deg); } }
 


### PR DESCRIPTION
fix(presentations): slow slide-5 ecosystem orbit to 60s/rev

Halve the orbit speed on the "A Growing Ecosystem" sphere. Both orbit rings
and their matched counter-rotations move together, so labels stay upright.

[AI-assisted - Claude]
