### PR TITLE
feat(presentations): pare Atlas slide to anchors, add Renegade repo URL

### DIFF
--- a/hugo-site/static/slides/futo/atlas/discovery.html
+++ b/hugo-site/static/slides/futo/atlas/discovery.html
@@ -5,15 +5,14 @@
 
     <!-- text -->
     <div style="flex: 1 1 auto; min-width: 280px; max-width: 440px; display: flex; flex-direction: column; gap: 1.0em;">
-      <blockquote style="font-size: 0.82em; width: 100%; margin: 0;">
-        On the web, whoever runs discovery (Google, the app store, the feed) decides what you can find.
-        And they answer to advertisers and engagement metrics, not to you.
+      <blockquote style="font-size: 0.9em; width: 100%; margin: 0;">
+        On the web, whoever runs discovery answers to advertisers, not you.
       </blockquote>
-      <p style="font-size: 0.92em; color: rgba(255,255,255,0.88); margin: 0;">
-        Atlas is Freenet's discovery layer: an <span class="highlight-purple">open, transparent index</span> hosted across the network, with no company in the middle.
+      <p style="font-size: 1.0em; color: rgba(255,255,255,0.88); margin: 0;">
+        Atlas: an <span class="highlight-purple">open, transparent index</span> on the network.
       </p>
-      <p style="font-size: 0.9em; color: rgba(255,255,255,0.88); font-weight: 600; margin: 0;">
-        You pick which index you trust and how it's ranked. <span class="highlight-green">Good defaults, and you're never locked in.</span>
+      <p style="font-size: 0.98em; color: rgba(255,255,255,0.9); font-weight: 600; margin: 0;">
+        You pick the index and the ranking. <span class="highlight-green">Good defaults, never locked in.</span>
       </p>
     </div>
 

--- a/hugo-site/static/slides/futo/renegade.html
+++ b/hugo-site/static/slides/futo/renegade.html
@@ -4,8 +4,8 @@
   <div style="flex: 1; display: flex; align-items: safe center; justify-content: safe center; gap: 1.8em; min-height: 0; width: 100%;">
 
     <!-- text (side column) -->
-    <div style="flex: 0 1 360px; min-width: 220px; display: flex; flex-direction: column; gap: 0.8em;">
-      <p style="font-size: 0.95em; color: rgba(255,255,255,0.9); margin: 0;">
+    <div style="flex: 0 1 360px; min-width: 220px; display: flex; flex-direction: column; gap: 0.5em;">
+      <p style="font-size: 0.86em; color: rgba(255,255,255,0.9); margin: 0;">
         Renegade is an <span class="highlight-green">open-source predictive model</span>: k-nearest neighbors with a learned metric, built for flexibility and good predictions from little data, no tuning.
       </p>
       <p style="font-size: 0.85em; color: rgba(255,255,255,0.8); margin: 0;">
@@ -17,6 +17,7 @@
       <div style="background: rgba(79,172,254,0.06); border-left: 2px solid rgba(79,172,254,0.45); border-radius: 4px; padding: 0.5em 0.75em;">
         <p style="font-size: 0.8em; color: rgba(255,255,255,0.82); margin: 0;">Like a CPU's <span class="highlight">branch predictor</span>: learn the likely path, don't stall.</p>
       </div>
+      <p style="font-size: 0.72em; color: rgba(255,255,255,0.45); margin: 0.1em 0 0;">Open source: <span style="color: rgba(255,255,255,0.62);">github.com/sanity/renegade</span></p>
     </div>
 
     <!-- graph (dominant) -->
@@ -40,7 +41,7 @@
     </ul>
     <p><strong>BACKUP (Q&amp;A / accuracy, not for live):</strong></p>
     <ul>
-      <li>Live in Freenet's routing since March 2026. Library is renegade-ml, open source.</li>
+      <li>Live in Freenet's routing since March 2026. Open source at github.com/sanity/renegade.</li>
       <li>Blended conservatively with the existing router, not trusted blindly, so a bad prediction can't tank routing.</li>
       <li>Privacy: each peer learns only from requests it already routes. No new data is collected, and nothing is shared between peers.</li>
     </ul>


### PR DESCRIPTION
feat(presentations): pare Atlas slide to anchors, add Renegade repo URL

Slide 16 (Atlas) copy trimmed from full-sentence script to spare anchors
(detail moved to speaker notes). Slide 10 (Renegade) gains the
github.com/sanity/renegade repo URL; stale "renegade-ml" name fixed.

[AI-assisted - Claude]
