### PR TITLE
feat(news): add "Services Without Servers" talk and feature it on the front page

### DIFF
--- a/hugo-site/content/_index.md
+++ b/hugo-site/content/_index.md
@@ -38,10 +38,10 @@ in just a few hops, scaling efficiently to millions of peers, no servers require
 ## Watch
 
 {{< talk-card
-    id="3SxNBz1VTE0"
-    title="Freenet Lives! Real-Time Decentralized Apps at Scale"
-    href="/about/news/freenet-lives-video-talk/"
-    caption="30-min talk at FUTO" >}}
+    id="3RBNboYUlVI"
+    title="Freenet: Services Without Servers"
+    href="/about/news/services-without-servers-video-talk/"
+    caption="July 2026 talk at FUTO" >}}
 
 </div>
 

--- a/hugo-site/content/about/news/services-without-servers-video-talk.md
+++ b/hugo-site/content/about/news/services-without-servers-video-talk.md
@@ -1,0 +1,21 @@
++++
+title = "Services Without Servers"
+date = 2026-07-24
+tags = ["video-talk", "front-page"]
++++
+
+Ian Clarke's July 2026 talk at FUTO is now available on YouTube. It is a progress update on
+Freenet: how the network works, and the applications running on it today.
+
+{{< youtube id="3RBNboYUlVI" >}}
+
+The talk walks through four applications you can use now: River for group chat, with private
+rooms newly added; Delta for publishing; Atlas for discovery and search, in its first working
+version; and freenet-git, which supports clone, fetch and push over Freenet. Along the way it
+covers contracts, how apps are delivered to the browser, and how to try Freenet with no install
+at [try.freenet.org](https://try.freenet.org).
+
+The theme running through all of it: these are the same pattern, applications whose backend is
+the network itself, so they can exist without a platform behind them.
+
+[Slides from the talk](/presentations/2026-07-17-apps-without-platforms/)


### PR DESCRIPTION
The July 17, 2026 FUTO talk was published to YouTube today ([3RBNboYUlVI](https://youtu.be/3RBNboYUlVI)). This adds it to the site and makes it the featured video on the homepage.

## Problem

The homepage "Watch" card still pointed at "Freenet Lives!" from February 2026, and the new talk was not on the site at all.

## Approach

Followed the existing pattern for video talks rather than adding anything new:

- New news entry `about/news/services-without-servers-video-talk.md`, tagged `["video-talk", "front-page"]` like every other talk. That single tagging gets it into the homepage News list *and* onto `/about/video-talks/` with no extra wiring.
- Homepage `talk-card` shortcode swapped to the new video id, title, href and caption.
- The article links to the slide deck already published at `/presentations/2026-07-17-apps-without-platforms/` (verified live, 200).

The old "Freenet Lives!" article is left untouched, so it stays in the archive on `/about/video-talks/`.

Article copy is drawn from the merged deck for this talk (PR #77) rather than guessed: the four shipping apps (River, Delta, Atlas, freenet-git) and the "backend is the network" theme are from the `app-status` and `closing` slides.

## Testing

- `hugo` build clean, 121 pages, no errors or warnings.
- Rendered locally and checked in a browser:
  - homepage card shows the new thumbnail (`naturalWidth` 480, so the image really loads from ytimg), title and caption, linking to the new article
  - article page embeds `youtube.com/embed/3RBNboYUlVI`
  - new entry is top of the homepage news list and top of `/about/video-talks/`
- Video metadata confirmed against the YouTube oEmbed API (title "Freenet - Services Without Servers", channel FUTO); speaker and setting confirmed from the video thumbnail.
- All outbound links checked for a 200: `try.freenet.org`, the slide-deck page.

[AI-assisted - Claude]