### PR TITLE
docs: point network dashboard links at https://telemetry.freenet.org

### DIFF
--- a/hugo-site/content/quickstart/_index.md
+++ b/hugo-site/content/quickstart/_index.md
@@ -57,7 +57,7 @@ Need to remove Freenet? See the [uninstall guide](/uninstall/).
 
 ## What's Next?
 
-- [Live Network Dashboard](http://nova.locut.us:3133/) - Watch real-time activity on the network
+- [Live Network Dashboard](https://telemetry.freenet.org/) - Watch real-time activity on the network
 - [User Manual](/build/manual/) - Learn how Freenet works
 - [Video Talks](/about/video-talks/) - Watch presentations about Freenet
 - [FAQ](/about/faq/) - Common questions and answers

--- a/hugo-site/static/slides/demo/dashboard-live.html
+++ b/hugo-site/static/slides/demo/dashboard-live.html
@@ -1,7 +1,7 @@
-<section data-background-iframe="http://nova.locut.us:3133" data-background-interactive>
+<section data-background-iframe="https://telemetry.freenet.org/" data-background-interactive>
   <div style="position: absolute; bottom: 20px; left: 20px; background: rgba(0,0,0,0.7); padding: 10px 20px; border-radius: 8px;">
     <h3 style="margin: 0; font-size: 1em;">Live Network Dashboard</h3>
-    <p style="margin: 0.3em 0 0 0; font-size: 0.7em; color: #aaa;">nova.locut.us:3133</p>
+    <p style="margin: 0.3em 0 0 0; font-size: 0.7em; color: #aaa;">telemetry.freenet.org</p>
   </div>
 
   <aside class="notes">

--- a/hugo-site/static/slides/demo/dashboard.html
+++ b/hugo-site/static/slides/demo/dashboard.html
@@ -7,7 +7,7 @@
     </div>
 
     <p style="margin-top: 0.8em; font-size: 0.9em; color: rgba(255,255,255,0.7);">
-      Live: <a href="http://nova.locut.us:3133" target="_blank" style="color: #4facfe;">nova.locut.us:3133</a>
+      Live: <a href="https://telemetry.freenet.org/" target="_blank" style="color: #4facfe;">telemetry.freenet.org</a>
       <span style="margin-left: 1.5em; font-size: 0.85em;">
         <a href="/slides/demo/telemetry-dashboard.webm" target="_blank" style="color: rgba(255,255,255,0.5);">[backup video]</a>
       </span>

--- a/hugo-site/themes/freenet/layouts/shortcodes/network-hero.html
+++ b/hugo-site/themes/freenet/layouts/shortcodes/network-hero.html
@@ -5,6 +5,6 @@
   </noscript>
 </div>
 <div class="network-hero-link">
-  <a href="http://nova.locut.us:3133/" target="_blank" rel="noopener">Live network dashboard &rarr;</a>
+  <a href="https://telemetry.freenet.org/" target="_blank" rel="noopener">Live network dashboard &rarr;</a>
 </div>
 <script src="{{ "js/network-hero.js" | relURL }}" defer></script>


### PR DESCRIPTION
## Problem

The telemetry dashboard has moved to HTTPS at https://telemetry.freenet.org (nova, via Caddy with a Let's Encrypt cert). The site still linked to `http://nova.locut.us:3133`.

The old URL now 301-redirects, so plain links would still work. But the slides **embed** the dashboard in an iframe (`data-background-iframe`), and a browser blocks an `http://` iframe inside an `https://` page as mixed content rather than following the redirect. Those embeds are broken until the URL is updated.

## Approach

Replace the dashboard URL in the four source files that reference it. Display text updated alongside hrefs so the visible label matches where the link goes.

- `hugo-site/content/quickstart/_index.md`
- `hugo-site/themes/freenet/layouts/shortcodes/network-hero.html`
- `hugo-site/static/slides/demo/dashboard.html`
- `hugo-site/static/slides/demo/dashboard-live.html`

`hugo-site/static/keys/gateways.toml` is deliberately **not** changed: that is `nova.locut.us:31337`, the gateway, which is unrelated to the dashboard. (It matches a naive `:3133` grep as a substring.)

`hugo-site/public/` is gitignored and regenerated at build time, so it is not touched here.

## Testing

- `hugo` build succeeds with no errors or warnings.
- Built output carries the new URL through to `index.html`, `quickstart/index.html`, `presentations/2026-02-06-freenet-lives/index.html`, and both demo slides.
- No `nova.locut.us:3133` references remain in the rendered site (only the unrelated `:31337` gateway entry).
- New host verified live: `https://telemetry.freenet.org/` returns 200 with a valid Let's Encrypt cert, and a real Chromium load reports the dashboard connected (`wss://telemetry.freenet.org/ws`, status "Live") with zero console errors.

[AI-assisted - Claude]