### PR TITLE
fix: stop the site switching to a phone layout on wide windows

### DIFF
--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -345,14 +345,17 @@
     }
 }
 
-/* The hero stacks below 1216px, which is where Bulma widens its container to
-   1152px. Two columns any earlier means a 960px container split in two, which
-   rendered the screenshot around 365px wide: a portrait sliver of a landscape
-   chat window, next to a copy column nearly twice its height. Stacking through
-   that band gives a full-width screenshot instead. The screenshot sits under
-   the copy so the headline, both CTAs and the caveat are all reachable without
-   scrolling past a tall image. */
-@media screen and (max-width: 1215px) {
+/* Two columns need enough width that the screenshot still reads as a landscape
+   chat window rather than a portrait sliver. That used to mean stacking below
+   1216px, because Bulma froze the container at 960px through the whole
+   1024-1215px band. The container is fluid now (see .container below), so the
+   width available to the hero tracks the window and the stack point can follow
+   the content instead of the framework: at 1024px the container is ~992px and
+   the screenshot column ~460px, the same width it renders at on a 1280px
+   window today. Below that it stacks, and the screenshot sits under the copy so
+   the headline, both CTAs and the caveat are all reachable without scrolling
+   past a tall image. */
+@media screen and (max-width: 1023px) {
     .hero-grid {
         grid-template-columns: minmax(0, 1fr);
         gap: 2rem;
@@ -399,9 +402,28 @@ a:hover {
     color: #0052cc;
 }
 
-/* Container padding adjustments */
+/* Bulma sizes .container in steps: full-bleed below 1024px, then a fixed 960px
+   from 1024px, 1152px from 1216px and 1344px from 1408px. Between the steps the
+   page width is frozen while the window grows, so a 1200px window rendered a
+   960px page with 120px of dead gutter either side, and widening from 1023px to
+   1024px made the content 63px NARROWER than it had just been. That frozen band
+   is what made the page feel like it had switched to a phone layout on a wide
+   window, and it is why the hero had to stack below 1216px. Grow the container
+   continuously instead. The 1344px ceiling is Bulma's own, so line length at
+   full width is unchanged; only the jumps go away. */
 .container {
+    width: 100%;
+    margin-inline: auto;
     padding: 0 16px;
+}
+
+/* Bulma raises its own steps with .container:not(.is-max-desktop) and
+   .container:not(.is-max-desktop):not(.is-max-widescreen), so a bare .container
+   selector loses to them above 1216px however late it is loaded. Match the
+   shape to outrank both, which also leaves the .is-max-* and .is-fluid opt-outs
+   working for anything that wants a narrower or unbounded container. */
+.container:not(.is-max-desktop):not(.is-max-widescreen):not(.is-fluid) {
+    max-width: 1344px;
 }
 
 /* Responsive padding for mobile */
@@ -506,8 +528,87 @@ p.page-end-spacer {
     cursor: pointer;
 }
 
+/* ---- Navbar collapse point ----
+   Bulma collapses the navbar to a burger below $navbar-breakpoint, which
+   defaults to 1024px. This navbar is four links and a wordmark: it measures
+   571px and still has 180px of slack at 769px, so the default threw away over
+   400px of usable width and put a phone menu on a 1000px window. $navbar-
+   breakpoint is a Sass variable and we ship Bulma as prebuilt CSS, so it cannot
+   be overridden at build time; instead restore Bulma's own desktop navbar rules
+   across the 769-1023px band. Keep this in sync with the two max-width: 768px
+   navbar queries below - together they are the collapse point. */
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+    .navbar,
+    .navbar-menu,
+    .navbar-start,
+    .navbar-end {
+        display: flex;
+        align-items: stretch;
+    }
+
+    .navbar-menu {
+        flex-grow: 1;
+        flex-shrink: 0;
+        background-color: transparent;
+        box-shadow: none;
+        padding: 0;
+    }
+
+    .navbar-start {
+        justify-content: flex-start;
+        margin-inline-end: auto;
+    }
+
+    .navbar-end {
+        justify-content: flex-end;
+        margin-inline-start: auto;
+    }
+
+    .navbar-item,
+    .navbar-link {
+        display: flex;
+        align-items: center;
+    }
+
+    .navbar-item.has-dropdown {
+        align-items: stretch;
+    }
+
+    .navbar-link:not(.is-arrowless)::after {
+        display: block;
+    }
+
+    .navbar-dropdown {
+        display: none;
+        position: absolute;
+        top: 100%;
+        inset-inline-start: 0;
+        min-width: 100%;
+        z-index: var(--bulma-navbar-dropdown-z);
+        font-size: 0.875rem;
+        background-color: var(--bulma-navbar-dropdown-background-color);
+        border-top: var(--bulma-navbar-dropdown-border-width) var(--bulma-navbar-dropdown-border-style) var(--bulma-navbar-dropdown-border-color);
+        border-bottom-left-radius: var(--bulma-navbar-dropdown-radius);
+        border-bottom-right-radius: var(--bulma-navbar-dropdown-radius);
+        box-shadow: 0 0.5em 0.5em hsla(var(--bulma-scheme-h), var(--bulma-scheme-s), var(--bulma-scheme-invert-l), 0.1);
+    }
+
+    .navbar-item.has-dropdown.is-active .navbar-dropdown {
+        display: block;
+    }
+
+    .navbar-dropdown .navbar-item {
+        padding: 0.375rem 1rem;
+        white-space: nowrap;
+    }
+
+    .navbar-burger {
+        display: none;
+    }
+}
+
 /* Pure CSS menu toggle - when checkbox is checked, show menu */
-@media screen and (max-width: 1023px) {
+@media screen and (max-width: 768px) {
     .navbar-toggle-checkbox:checked ~ .navbar-menu {
         display: block;
     }
@@ -557,11 +658,16 @@ p.page-end-spacer {
     display: none;
 }
 
-@media screen and (max-width: 1023px) {
+@media screen and (max-width: 768px) {
     .navbar-end .navbar-item.donate-nav-button {
         display: none;
     }
 
+    /* Bulma already gives .navbar-burger margin-inline-start: auto. A second
+       auto margin here would split the free space between the two instead of
+       collecting it before them, stranding Donate in the middle of the bar
+       rather than pairing it with the burger. Push with this one and zero
+       Bulma's so the pair sits together at the right. */
     .navbar-item.donate-nav-button-mobile {
         display: inline-flex;
         align-items: center;
@@ -569,6 +675,10 @@ p.page-end-spacer {
         margin-right: 0.5rem;
         padding: 0.3rem 0.95rem;
         font-size: 0.9rem;
+    }
+
+    .navbar-burger {
+        margin-inline-start: 0;
     }
 }
 


### PR DESCRIPTION
## Problem

The site drops to a stacked, burger-menu layout while the browser window is still wide. Reported as "switches to mobile mode even when the browser is still quite wide."

Measured on `main`, there are two separate triggers, and neither is driven by what the content actually needs:

| Viewport | Container | Homepage hero | Navbar |
|---|---|---|---|
| 1600px | 1344px | 2 columns | full |
| 1300px | 1152px | 2 columns | full |
| **1200px** | **960px** | **stacked** | full |
| 1100px | 960px | stacked | full |
| 1024px | 960px | stacked | full |
| **1023px** | **1023px** | stacked | **burger** |

At 1200px the page renders 960px of content between two 120px gutters, with the hero stacked and the River screenshot pushed below the fold.

## Root cause

Both thresholds are downstream of Bulma's **stepped `.container`**: full-bleed below 1024px, then frozen at 960px until 1216px, 1152px until 1408px, 1344px above. Two consequences:

1. Through the whole 1024–1215px band the page width does not grow with the window. On a 1200px window that is 240px of dead gutter.
2. Widening from 1023px to 1024px makes the content **63px narrower** than it just was — the layout moves backwards as you enlarge the window.

The hero's 1216px stack point was a workaround for (1): the existing code comment says two columns inside a 960px container rendered the screenshot ~365px wide, "a portrait sliver of a landscape chat window." It stacked early because the container refused to use the available width.

The navbar is separate but the same shape of problem: Bulma collapses it below `$navbar-breakpoint` (1024px default). This nav is a wordmark and four links. Measured, it needs **571px** and still has ~180px of slack at 769px, so the default discarded over 400px of usable width to show a phone menu on a 1000px window.

## Approach

Fix the container first, then let both stack points follow the content:

- **`.container` grows continuously** up to Bulma's own 1344px ceiling. Because Bulma raises its steps with `.container:not(.is-max-desktop)` and `.container:not(.is-max-desktop):not(.is-max-widescreen)`, a bare `.container` selector loses to them above 1216px however late it loads; the override matches that selector shape, which also keeps the `.is-max-*` and `.is-fluid` opt-outs working.
- **Hero stacks below 1024px** instead of 1216px. At 1024px the screenshot column is ~460px, the same width it renders at on a 1280px window on `main` today.
- **Navbar collapses below 769px** instead of 1024px. `$navbar-breakpoint` is a Sass variable and we ship Bulma as prebuilt CSS, so it cannot be set at build time; instead Bulma's own desktop navbar rules are restored across the 769–1023px band.
- **Mobile Donate button pairs with the burger.** Bulma already gives `.navbar-burger` `margin-inline-start: auto`, so the button's own auto margin split the free space between them and stranded Donate in the middle of the bar.

The container is **never narrower than before at any width**, and is byte-identical at 1408px and above.

## Testing

Playwright, all **93 sitemap pages** at ten widths from 375px to 1600px, light and dark:

- **No new horizontal overflow.** 18 overflows exist on `main` (wide code blocks on `/build/manual/*`, video embeds on `/about/news/*`, mostly at 375px); the same 18 appear after, unchanged. None are touched by this PR — see below.
- **Navbar state correct at every width** on every page (full ≥769px, burger ≤768px).
- **Dropdowns open, land on-screen and are clickable** in all three modes: desktop, the new 769–1023px band, and burger.
- Container grows monotonically 320px → 1344px with no jumps and no reversals.
- `hugo --environment production --minify` builds clean.

## Not in this PR

Two pre-existing issues found while measuring, both worth their own change:

1. **18 horizontal-overflow bugs** on manual and news pages at narrow widths (up to +389px on `/build/manual/contract-abi/` at 375px), from unconstrained `<pre>` blocks and video embeds. Present on `main`, unaffected either way by this PR.
2. **No prose measure cap.** Body paragraphs run the full container width, so on a 1600px screen a paragraph is ~1088px ≈ 140 characters per line, well past the 45–75 that is comfortable. This is pre-existing at ≥1408px; making the container fluid means the widest measure is now reached at narrower windows too. The standard fix is to cap the text column (~70ch) independently of the layout container, but that visibly narrows every content page and is a design call rather than a bug fix.

[AI-assisted - Claude]