### PR TITLE
fix: stop the open burger menu running off the right edge on phones

### DIFF
--- a/hugo-site/themes/freenet/assets/css/base.css
+++ b/hugo-site/themes/freenet/assets/css/base.css
@@ -362,9 +362,13 @@ pre code {
    spare.
    ========================================================================== */
 
+/* Deliberately NOT display: flex here. In burger mode the opened .navbar-menu
+   has to stack underneath .navbar-brand, and a flex .navbar makes it a second
+   item in the same row instead: it lands beside the logo at the full height of
+   the bar, shrunk to its content width and mostly past the right edge, so the
+   page scrolls sideways. The row layout belongs to the horizontal navbar only,
+   and is set in the min-width: 769px block below. */
 .navbar {
-    align-items: stretch;
-    display: flex;
     min-height: 3.25rem;
     position: relative;
     z-index: 30;
@@ -497,13 +501,11 @@ a.navbar-item:focus {
 
 /* ---- Collapsed (burger) mode -------------------------------------------- */
 @media screen and (max-width: 768px) {
-    /* .navbar-menu is hidden here, so .navbar-brand has to claim the width for
-       itself. Without this it shrink-wraps its contents, leaving no free space
-       for the Donate button's auto margin to collect, and the logo, Donate and
-       burger bunch up against the left edge. */
-    .navbar-brand {
-        flex-grow: 1;
-    }
+    /* .navbar is a block here, so .navbar-brand is a block-level flex container
+       and already spans the bar. That full width is what gives the Donate
+       button's auto margin something to collect; if .navbar-brand ever
+       shrink-wrapped instead, the logo, Donate and burger would bunch up
+       against the left edge. */
 
     /* No auto margin here on purpose. The Donate button that precedes it in
        .navbar-brand carries margin-inline-start: auto, which collects the free
@@ -538,17 +540,20 @@ a.navbar-item:focus {
         transform: translateY(-5px) rotate(-45deg);
     }
 
-    /* Stacked menu: dropdowns open inline rather than as an overlay. */
-    .navbar-link::after {
-        display: none;
-    }
+    /* Stacked menu: every section is already open, so the whole nav is one
+       scrollable list and each destination is a single tap from the burger.
+       This is what Bulma did, and it matters beyond the extra tap: the
+       top-level "About" / "Build" / "Apps" items are toggles with no href, so
+       collapsing them by default put every sub-page behind a JS handler and
+       made the menu a dead end with scripting disabled. The whole navbar is
+       otherwise pure CSS, driven by the #navbar-toggle checkbox.
 
-    .navbar-dropdown {
+       No arrow on the section headings either, since there is nothing left to
+       expand. The :not(.is-arrowless) has to be repeated here to outrank the
+       base rule that draws the chevron; a plain .navbar-link::after loses to
+       it, and the arrow survives promising an expand that does not exist. */
+    .navbar-link:not(.is-arrowless)::after {
         display: none;
-    }
-
-    .navbar-item.has-dropdown.is-active .navbar-dropdown {
-        display: block;
     }
 
     .navbar-dropdown .navbar-item {
@@ -558,6 +563,7 @@ a.navbar-item:focus {
 
 /* ---- Horizontal mode ---------------------------------------------------- */
 @media screen and (min-width: 769px) {
+    .navbar,
     .navbar-menu,
     .navbar-start,
     .navbar-end {


### PR DESCRIPTION
Follow-up to #91. Reported on Android: opening the burger menu pushes the page sideways.

## Problem

`.navbar` was `display: flex` at every width. In burger mode that made the opened `.navbar-menu` a **second flex item in the same row** as `.navbar-brand` rather than a block underneath it, so it landed beside the logo at the full height of the bar, shrunk to its content width, and hung off the right edge.

| viewport | page overflow, menu open |
|---|---|
| Pixel 7 (412px) | 26px |
| plain 412px | 22px |
| 360px | 52px |
| Galaxy S9+ (320px) | 96px |

Bulma only made `.navbar` a flex container at its own breakpoint, which is why this did not happen before #91.

## Approach

The row layout belongs to the horizontal navbar, so it moves into the `min-width: 769px` block. With `.navbar` back to a block below that, `.navbar-brand` is a block-level flex container that already spans the bar, which is exactly what the Donate button's auto margin needs, so the `flex-grow` added for that is no longer required and goes.

## Second regression, found while reviewing this fix

Also from #91, also live. Bulma left dropdowns **expanded** in the stacked menu; I ported its desktop "collapse" rule into the burger block, which hid them behind a tap.

That matters beyond the extra tap. The top-level `About` / `Build` / `Apps` items are toggles with **no href**, so collapsing them put every sub-page behind a JS handler:

| | sub-links reachable on mobile, JS **off** |
|---|---|
| before #91 | 14 |
| after #91 (live now) | 0 |
| this PR | 14 |

The whole navbar is otherwise pure CSS driven by the `#navbar-toggle` checkbox, so it worked fine without scripting until that change. Sections are expanded again: the menu is one list and every destination is a single tap. The chevron goes with them, since nothing expands any more — that needs `:not(.is-arrowless)` repeated to outrank the base rule, or the arrow survives and promises an expand that does not exist.

## Testing

Verified against both `origin/main` and the pre-removal commit (`4e93de0f`), served side by side:

- **Open-menu overflow 0** on Pixel 7, Galaxy S9+, 412, 360, 320 and 768.
- **454 of 455 page/width combinations clean with the menu OPEN** (93 pages × burger widths), asserting page overflow, that the menu stacks below the bar, and that every menu link is inside the viewport. The single failure is a fixed `width="350"` canvas on `/build/manual/further-reading/small-world-networks/` at a 320px viewport; it overflows with the menu **closed** too and predates all of this — see below.
- **Sub-links reachable with JavaScript disabled**: 14/14, matching pre-removal.
- **Burger tap through to a destination link** works under touch emulation at Pixel 7 and 360×800.
- **Desktop unchanged**: identical container widths, hero columns and Donate/burger positions across 18 widths; dropdowns still open, land on-screen and are clickable at 1280, 1000, 800 and 769.
- 93 pages × 10 widths with the menu closed: still zero overflow.
- `hugo --environment production --minify` builds clean.

## The gap that let this ship

The sweep in #91 measured page overflow with the menu **closed**, and inspected the open menu only for whether one dropdown link was clickable — which passed, because the link was technically within bounds even while the menu hung off the edge. The new `sweep-open.mjs` opens the menu on every page at every burger-range width and asserts overflow, stacking and link reachability.

## Not in this PR

`/build/manual/further-reading/small-world-networks/` overflows 15px at a 320px viewport from a `<canvas>` and `<svg>` hard-coded to 350px with inline styles, whose JS sizes off that buffer. Pre-existing, unrelated to the menu, only affects viewports below ~334px, and scaling it needs the animation checked rather than a blind CSS clamp. Worth its own change.

[AI-assisted - Claude]