### PR TITLE
feat(ghostkey): fix donation funnel conversion and suppress Stripe Link

### DIFF
--- a/hugo-site/content/donate/_index.md
+++ b/hugo-site/content/donate/_index.md
@@ -67,3 +67,13 @@ If you are interested in supporting Freenet at a significant level, we would be 
 <a href="https://www.paypal.com/donate?hosted_button_id=EQ9E7DPHB6ETY" class="funding-donate-button">Donate via PayPal</a>
 
 </div>
+
+<div class="funding-section funding-ghost-keys">
+
+## Donating by card
+
+If you would rather give by card, you can donate through [Ghost Keys](/ghostkey/). A Ghost Key is an
+anonymous cryptographic identity, issued with your donation, that works across Freenet apps and
+cannot be linked back to your payment. The minimum is $1.
+
+</div>

--- a/hugo-site/content/ghostkey/_index.md
+++ b/hugo-site/content/ghostkey/_index.md
@@ -10,6 +10,25 @@ You hold your Ghost Keys in the **Ghostkey Vault**, a Freenet delegate running i
 your Freenet node, and any Freenet app can ask the vault to sign with one to prove you
 hold a scarce, donation-backed identity, without ever learning who you are.
 
+<div class="gk-cta gk-cta-hero">
+<a href="/ghostkey/create/" class="funding-donate-button">Get a Ghost Key</a>
+<p class="gk-cta-note">$1 minimum. Freenet Project Inc is a 501(c)(3) nonprofit.</p>
+</div>
+
+## The short version
+
+- **What you get.** An identity that any Freenet app can verify, and that no one can
+  trace back to your payment.
+- **What it costs.** $1 or more, once. There is no subscription and nothing renews.
+- **Why a donation.** Identities that are free to create are free to farm. Paying for
+  one makes spam and Sybil attacks expensive, and it funds Freenet's development.
+- **How the anonymity works.** Your browser blinds the key before the donation server
+  ever sees it, so the server signs a key it cannot read.
+  [Details below](#how-it-works-blind-signing).
+- **What it does not do.** It does not make everything you sign unlinkable. Two messages
+  signed with the same Ghost Key can be tied to the same holder.
+  [We are specific about this](#what-ghost-keys-dont-hide).
+
 You can also read the [introductory article](/about/news/introducing-ghost-keys/) or
 [watch the interview](/about/news/ghost-keys-ian-interview/).
 
@@ -109,6 +128,11 @@ zero-knowledge proof over the certificate. It would require redesigning the sign
 format and the verifier, and is a substantial piece of work, but it is the direction
 we expect Ghost Keys to move in.
 
+<div class="gk-cta">
+<a href="/ghostkey/create/" class="funding-donate-button">Get a Ghost Key</a>
+<p class="gk-cta-note">$1 minimum. You now know both what it protects and what it doesn't.</p>
+</div>
+
 ## Using Ghost Keys from a Freenet app
 
 Once imported, your Ghost Key doesn't just sit in a file. It lives inside the
@@ -175,6 +199,18 @@ The minimum is **$1**. Donate as much as you can; the amount is recorded in your
 certificate, so apps that want to grant additional privileges to larger donors can do
 so.
 
-<p style="text-align: center; margin: 2.5rem 0;">
-<a href="/ghostkey/create/" class="funding-donate-button">Donate to Get Your Ghost Key</a>
-</p>
+### Why the amounts are fixed
+
+You choose from $1, $5, $20, $50, or $100 rather than typing your own figure, and that
+is a privacy decision rather than a limitation we haven't got around to lifting.
+
+The donation amount is written into your certificate, so anyone who verifies it can read
+it. Fixed tiers mean your certificate is indistinguishable from every other certificate
+issued at the same amount: the amount tells an observer which of five groups you are in
+and nothing more. A free-form amount like $37.42 would be close to unique, and would
+give away much of what blind signing is there to protect.
+
+<div class="gk-cta">
+<a href="/ghostkey/create/" class="funding-donate-button">Get a Ghost Key</a>
+<p class="gk-cta-note">$1 minimum. Freenet Project Inc is a 501(c)(3) nonprofit.</p>
+</div>

--- a/hugo-site/content/ghostkey/create/_index.md
+++ b/hugo-site/content/ghostkey/create/_index.md
@@ -10,6 +10,11 @@ your donation and signs a key it cannot read. Your browser then unblinds that si
 your [Ghost Key](/ghostkey/) certificate. The result is an identity we can verify but cannot connect
 to your payment.
 
+What it protects is that link. It is not a fresh disguise for everything you later do with it: a
+Ghost Key is a persistent pseudonym, and two messages signed with the same one can be tied to the
+same holder. We set out the limits in
+[what Ghost Keys don't hide](/ghostkey/#what-ghost-keys-dont-hide).
+
 > **Before you pay:** after donating you'll download your certificate and signing key, and that
 > download is the authoritative copy. Keep it somewhere safe, such as a secure note in a password
 > manager. The Ghostkey Vault you can import it into is still experimental and can currently lose

--- a/hugo-site/content/ghostkey/create/_index.md
+++ b/hugo-site/content/ghostkey/create/_index.md
@@ -28,13 +28,16 @@ is a 501(c)(3) nonprofit, and contributions are tax-deductible in the United Sta
 ## Who sees what
 
 - **Stripe**, our payment processor: your card details and the amount. Stripe never sees your Ghost
-  Key.
-- **Freenet's donation server**: that a donation happened, the amount, and a blinded key it is
-  mathematically unable to read.
+  Key, blinded or otherwise.
+- **Freenet's donation server**: your payment record from Stripe, which it has to read in order to
+  confirm the payment succeeded, and separately a blinded key that it is mathematically unable to
+  read.
 - **Anyone verifying your key later**: that a valid Ghost Key was issued at a given donation tier.
   Not your name, not your payment.
 
-Nobody, including us, ever holds both halves.
+The unblinding happens in your browser, on a key our server never sees in unblinded form. So while
+our server does handle your payment, the link between that payment and the Ghost Key you end up
+holding is never created anywhere, including on our own machines.
 
 ## Why the amounts are fixed
 

--- a/hugo-site/content/ghostkey/create/_index.md
+++ b/hugo-site/content/ghostkey/create/_index.md
@@ -5,21 +5,44 @@ draft: false
 layout: "single"
 ---
 
-After you donate to Freenet, you'll receive a certified [Ghost Key](/ghostkey/), a cryptographic key.
-The key is generated in your browser, then "blinded" before being sent to our server. The server
-signs the blinded key without ever seeing the unblinded version, ensuring that your donation remains
-anonymous. Your browser then unblinds the signature, creating a signed certificate.
+Your browser generates a key and *blinds* it before sending it to our server. The server confirms
+your donation and signs a key it cannot read. Your browser then unblinds that signature, producing
+your [Ghost Key](/ghostkey/) certificate. The result is an identity we can verify but cannot connect
+to your payment.
 
-It's important to store this certificate securely, such as in a secure note within your password
-manager. You can read an article about Ghost Keys [here](/about/news/introducing-ghost-keys/).
+> **Before you pay:** after donating you'll download your certificate and signing key, and that
+> download is the authoritative copy. Keep it somewhere safe, such as a secure note in a password
+> manager. The Ghostkey Vault you can import it into is still experimental and can currently lose
+> keys ([freenet/ghostkeys#3](https://github.com/freenet/ghostkeys/issues/3)), so the backup is what
+> protects you.
 
-We offer a $1 donation option to ensure that Ghost Keys are accessible to everyone, especially those
-with limited means. Your generosity directly supports the ongoing development of Freenet, helping us
-build a more private, secure, and decentralized internet. Your donation amount will be recorded in
-the Ghost Key certificate and could provide additional benefits in the future.
-
-We use [Stripe](https://stripe.com/) for credit card processing.
+The minimum is **$1**. We use [Stripe](https://stripe.com/) for card processing. Freenet Project Inc
+is a 501(c)(3) nonprofit, and contributions are tax-deductible in the United States.
 
 {{< spacer >}}
 
 {{< stripe-donation-form error-message="The Ghost Key service is down, please notify webmaster@freenet.org" >}}
+
+{{< spacer >}}
+
+## Who sees what
+
+- **Stripe**, our payment processor: your card details and the amount. Stripe never sees your Ghost
+  Key.
+- **Freenet's donation server**: that a donation happened, the amount, and a blinded key it is
+  mathematically unable to read.
+- **Anyone verifying your key later**: that a valid Ghost Key was issued at a given donation tier.
+  Not your name, not your payment.
+
+Nobody, including us, ever holds both halves.
+
+## Why the amounts are fixed
+
+You choose from a short list rather than typing your own figure. The donation amount is recorded in
+your certificate and is visible to anyone who verifies it, so fixed tiers keep your certificate
+indistinguishable from every other one issued at the same amount. A free-form figure like $37.42
+would be close to unique, and would give away much of what blind signing is there to protect.
+
+The $1 tier exists so that Ghost Keys stay within reach of people with limited means. Anything above
+it directly funds Freenet's development, and apps that want to extend extra privileges to larger
+donors can read the tier from your certificate.

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -1274,6 +1274,42 @@ picture.app-screenshot img {
   color: #ffffff !important;
 }
 
+/* Ghost Key call to action, used on /ghostkey/ at the top, after the
+   limitations section, and at the end.
+
+   Deliberately NOT reusing the homepage .cta-row/.cta-note pair: those carry a
+   negative top margin tuned to sit under the homepage hero, which collapses
+   badly in the middle of a prose page. Same visual language, no positional
+   assumptions.
+
+   The note under the button carries the price and the nonprofit status. Both
+   belong here rather than in the button label: the reader should know what the
+   click costs before making it, not after. */
+.gk-cta {
+  margin: 2.5rem 0;
+  text-align: center;
+}
+
+.gk-cta-note {
+  margin: 0.75rem auto 0 auto;
+  max-width: 34rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #64748b;
+}
+
+/* The hero CTA sits directly under the opening definition, so it needs less
+   space above it than the in-body instances. */
+.gk-cta-hero {
+  margin-top: 1.75rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .gk-cta-note {
+    color: #94a3b8;
+  }
+}
+
 /* Ghost keys — understated */
 .funding-ghost-keys {
   padding-top: 1.5rem;

--- a/hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html
+++ b/hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html
@@ -1,8 +1,8 @@
 <div id="stripe-donation-form" style="max-width: 400px; margin: auto; padding: 20px; border: 1px solid #ccc; border-radius: 10px; background-color: #f9f9f9;">
     <form id="payment-form">
-    <!-- These tiers are NOT free to change. Each one needs a matching per-amount
+    {{/* These tiers are NOT free to change. Each one needs a matching per-amount
          notary keypair on the API host (notary_certificate_{amount}.pem and
-         notary_signing_key_{amount}.pem — see rust/api/src/delegates.rs). An
+         notary_signing_key_{amount}.pem, see rust/api/src/delegates.rs). An
          amount with no keypair fails certificate signing AFTER the card has been
          charged, leaving the donor paid up with no key.
 
@@ -11,7 +11,10 @@
          free-form amount would be near-unique. Do not add a custom-amount field.
 
          If you change this list, update the prose that names the tiers in
-         hugo-site/content/ghostkey/_index.md ("Why the amounts are fixed"). -->
+         hugo-site/content/ghostkey/_index.md ("Why the amounts are fixed").
+
+         Go-template comment rather than an HTML one so this stays in source
+         without shipping to every visitor. */}}
     <div id="amount-options" style="margin-bottom: 20px;">
         <label class="donation-amount-label"><input type="radio" name="amount" value="1" required> $1</label>
         <label class="donation-amount-label"><input type="radio" name="amount" value="5" checked> $5</label>

--- a/hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html
+++ b/hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html
@@ -75,11 +75,22 @@
         loader: 'auto',
       });
 
+      // Suppress Stripe Link. Its inline signup asks for email, phone number,
+      // and full name at the moment of payment, which directly contradicts what
+      // a Ghost Key is for: a donor who came here for an unlinkable identity
+      // should not be asked to hand over contact details to complete the
+      // donation. `wallets.link` is the documented lever for this.
+      //
+      // This replaces a `linkAuthenticationElement` option that was silently
+      // doing nothing. It is not a valid key for elements.create('payment'),
+      // whose options are layout, defaultValues, business, paymentMethodOrder,
+      // fields, readOnly, terms, wallets and applePay. Unknown keys are ignored
+      // rather than rejected, so the Link prompt had been showing in production
+      // despite the apparent intent to disable it.
       const paymentElementOptions = {
         layout: "tabs",
-        linkAuthenticationElement: {
-          type: "auto",
-          visibility: "never",
+        wallets: {
+          link: "never",
         },
       };
 

--- a/hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html
+++ b/hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html
@@ -1,5 +1,17 @@
 <div id="stripe-donation-form" style="max-width: 400px; margin: auto; padding: 20px; border: 1px solid #ccc; border-radius: 10px; background-color: #f9f9f9;">
     <form id="payment-form">
+    <!-- These tiers are NOT free to change. Each one needs a matching per-amount
+         notary keypair on the API host (notary_certificate_{amount}.pem and
+         notary_signing_key_{amount}.pem — see rust/api/src/delegates.rs). An
+         amount with no keypair fails certificate signing AFTER the card has been
+         charged, leaving the donor paid up with no key.
+
+         Fixed tiers are also load-bearing for anonymity: the amount is written
+         into the certificate and is visible to anyone who verifies it, so a
+         free-form amount would be near-unique. Do not add a custom-amount field.
+
+         If you change this list, update the prose that names the tiers in
+         hugo-site/content/ghostkey/_index.md ("Why the amounts are fixed"). -->
     <div id="amount-options" style="margin-bottom: 20px;">
         <label class="donation-amount-label"><input type="radio" name="amount" value="1" required> $1</label>
         <label class="donation-amount-label"><input type="radio" name="amount" value="5" checked> $5</label>


### PR DESCRIPTION
## Problem

The Ghost Key donation flow asked people to scroll past the entire explanation before offering them any way to act, and the checkout page contradicted the product it was selling.

Measured on the live site before this change:

| | Desktop | Mobile |
|---|---|---|
| `/ghostkey/` height | 5,525px (6.1 screens) | 8,320px (9.9 screens) |
| Only CTA appears at | **95% down** | **96% down** |

Roughly 2,900 words before the first opportunity to donate. Separately:

- The nav **Donate** button, the most prominent donation path on the site, goes to `/donate/`, which never mentioned Ghost Keys.
- The Stripe checkout renders Link's inline signup asking for **email, mobile number and full name** at the moment of payment, on a page whose entire proposition is that the donation cannot be linked to the key.
- The "the Ghostkey Vault is experimental and can lose keys" warning appeared only on the success page, **after** payment.
- `/ghostkey/create/` contained the line "could provide additional benefits in the future", the one piece of copy on the page that read like a token sale.

## Approach

No dark patterns. Nothing added here manufactures urgency, hides the $1 option, or pressures the reader. The two structural moves are deliberately trust-first:

- The mid-page CTA is placed **after** "What Ghost Keys don't hide", not before, so nobody is asked to pay before seeing the limitations.
- The experimental-vault disclosure moves **before** payment. Disclosing a material limitation only after taking someone's money is the shape of a dark pattern even when the intent is honest.

Nothing is deleted from the explainer. The full text is unchanged; it stops being a toll gate.

The checkout page gained content but the payment form still starts **0.66 screens down on desktop**, the same as before, so no checkout friction was added.

### On the custom-amount idea, which I dropped

I had recommended adding a free-form amount field. Checking the API first showed that would be actively harmful:

- `handle_sign_cert.rs` computes `amount_dollars = amount_cents / 100` and calls `get_notary(amount_dollars)`, which reads a **per-amount** keypair (`notary_certificate_{amount}.pem`). An unlisted amount has no keypair, so cert signing fails **after the card is charged**. Worst possible failure: charged, no key.
- The amount is written into the certificate and is visible to any verifier, so fixed tiers are load-bearing for anonymity. A free-form figure like \$37.42 would be close to unique.

So instead of adding the field, both pages now explain why the tiers are fixed, turning something that looks like an unfinished form into the privacy property it actually is.

## Testing

Verified against the live Stripe API by loading the built site and scanning every frame for Link artifacts:

```
PRODUCTION (current): ['Email', 'Mobile number', 'Save my information', 'checkout with Link']
LOCAL (with fix)    : NONE (clean)
```

CTA positions after the change (built site, measured in Chromium):

| | Hero CTA | Mid CTA | Final CTA |
|---|---|---|---|
| Desktop | 5% down | 55% | 95% |
| Mobile | 4% down | 54% | 96% |

Also checked: `hugo` build clean, light and dark mode on both pages, desktop (1280) and mobile (390) renders, and that `/donate/` now links to `/ghostkey/`.

### Note on the Stripe fix

`linkAuthenticationElement` is not a valid key for `elements.create('payment', ...)`; the documented options are `layout`, `defaultValues`, `business`, `paymentMethodOrder`, `fields`, `readOnly`, `terms`, `wallets`, `applePay`. Unknown keys are ignored rather than rejected, so the previous code looked like it disabled Link while Link had been showing in production the whole time. Replaced with `wallets: { link: 'never' }`.

The `/donate/` section reuses `.funding-ghost-keys`, a style already in the theme (commented "Ghost keys — understated") that no content had ever used.

[AI-assisted - Claude]