### PR TITLE
docs: drop "serverless thing" from the homepage hero note

### DIFF
--- a/hugo-site/content/_index.md
+++ b/hugo-site/content/_index.md
@@ -23,8 +23,8 @@ in the middle.
 </div>
 
 <p class="cta-note">The browser version is a centralized demo running on our server. Installing your
-own peer takes a couple of minutes on Windows, macOS or Linux, and gives you the real, serverless
-thing.</p>
+own peer takes a couple of minutes on Windows, macOS or Linux, and gives you the real thing, with no
+server in the middle.</p>
 
 </div>
 


### PR DESCRIPTION
## Problem

The homepage hero note under the CTA buttons read:

> The browser version is a centralized demo running on our server. Installing your own peer takes a couple of minutes on Windows, macOS or Linux, and gives you the real, **serverless thing**.

"Serverless thing" is awkward, and "serverless" is worse than awkward: in the cloud industry it means running your code on someone else's servers (Lambda, Cloud Functions). That is close to the opposite of what a Freenet peer does, so the word actively misleads the readers most likely to recognise it.

## Approach

Replace the jargon with plain English that matches the wording already used higher in the hero ("with nobody in the middle"):

> ... and gives you the real thing, with no server in the middle.

Content-only change: one sentence in `hugo-site/content/_index.md`. No template, style, or code changes.

## Testing

- `hugo` builds clean (exit 0, no warnings).
- Verified the rendered `.cta-note` paragraph in the built `index.html` contains the new sentence, and that "serverless" no longer appears anywhere in the built homepage or in the repo.

[AI-assisted - Claude]