### PR TITLE
Fix page layout width and section navigation

### DIFF
--- a/hugo-site/themes/freenet/assets/css/base.css
+++ b/hugo-site/themes/freenet/assets/css/base.css
@@ -279,10 +279,51 @@ pre code {
    be. Wide children (code blocks, tables) still scroll within it. */
 .container.is-prose {
     max-width: var(--measure-container);
+    font-size: 1.125rem;
+    line-height: 1.6;
     /* The column itself is now the measure, so switch off the per-block cap
        below. Leaving both on would cap the text a second time inside an
        already-narrow column and strand it again, just less obviously. */
     --measure: none;
+}
+
+/* Section landing pages are navigation surfaces, not long-form articles. Keep
+   their shell wide so child pages can form a useful card grid, while the
+   reading-measure rule below still caps introductory prose inside .content. */
+.container.is-section-page {
+    max-width: 1344px;
+}
+
+.page-list.is-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 32rem));
+    justify-content: start;
+    margin-top: 2.5rem;
+}
+
+.page-list.is-grid .child-entry {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 0.75rem;
+    margin-bottom: 0;
+    padding: 1.5rem;
+}
+
+.page-list .child-entry > .title a {
+    color: var(--text-strong);
+}
+
+@media screen and (max-width: 768px) {
+    .page-list.is-grid {
+        gap: 1rem;
+        grid-template-columns: minmax(0, 1fr);
+        margin-top: 2rem;
+    }
+
+    .page-list.is-grid .child-entry {
+        padding: 1.25rem;
+    }
 }
 
 /* Tables, code blocks and figures are read by scanning rather than line by

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -105,14 +105,15 @@
     --code-background: #f3f4f6;
 
     /* Reading measure. Body text was running the full container width, which
-       is ~175 characters on a 1600px screen; comfortable reading is 45-75.
+       is ~175 characters on a 1600px screen; comfortable reading is roughly
+       45-90, with long-form copy best kept near the middle of that range.
 
        --measure-container sizes the article column on prose pages, so the
        heading and body move together. --measure is the per-block fallback for
        prose inside a full-width layout (the homepage), where the container has
        to stay wide for the hero and the card grid. --breakout is how far
        tables, code blocks and figures may extend past the column. */
-    --measure-container: 36rem;
+    --measure-container: 42rem;
     --measure-content: calc(var(--measure-container) - 2rem); /* less .container padding */
     --breakout: 52rem;
     --measure: 66ch;

--- a/hugo-site/themes/freenet/layouts/_default/list.html
+++ b/hugo-site/themes/freenet/layouts/_default/list.html
@@ -1,36 +1,34 @@
 {{ define "main" }}
-  <section class="section">
-    <div class="container is-prose">
-      <h1 class="title">{{ .Title }}</h1>
-      {{ if .IsSection }}
-        <div class="content">
-          {{ .Content }}
-        </div>
-        <div>
-          {{ range .Pages }}
-              <section class="child-entry">
-                <h2 class="title is-5">
-                  <a href="{{ .RelPermalink }}" style="color: #444444;">{{ .LinkTitle }}</a>
-                </h2>
-                {{ if eq .Section "news" }}
-                  <p class="date">{{ .Date.Format "2 January, 2006" }}</p>
-                {{ end }}
-                <div class="content">
-                  {{ .Summary }}
-                </div>
-              </section>
-          {{ end }}
-        </div>
-      {{ else }}
-        {{ if eq .Section "news" }}
-          {{ $dateMachine := .Date | time.Format "2006-01-02T15:04:05-07:00" }}
-          {{ $dateHuman := .Date | time.Format ":date_long" }}
-          <p class="date">{{ $dateHuman }}</p>
+  <div class="container{{ if .IsSection }} is-section-page{{ else }} is-prose{{ end }}">
+    <h1 class="title">{{ .Title }}</h1>
+    {{ if .IsSection }}
+      <div class="content page-intro">
+        {{ .Content }}
+      </div>
+      <div class="page-list{{ if not .Params.list_child_pages }} is-grid{{ end }}">
+        {{ range .Pages }}
+          <section class="child-entry">
+            <h2 class="title is-5">
+              <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+            </h2>
+            {{ if eq .Section "news" }}
+              <p class="date">{{ .Date.Format "2 January, 2006" }}</p>
+            {{ end }}
+            <div class="content">
+              {{ .Summary }}
+            </div>
+          </section>
         {{ end }}
-        <div class="content">
-          {{ .Content }}
-        </div>
+      </div>
+    {{ else }}
+      {{ if eq .Section "news" }}
+        {{ $dateMachine := .Date | time.Format "2006-01-02T15:04:05-07:00" }}
+        {{ $dateHuman := .Date | time.Format ":date_long" }}
+        <p class="date">{{ $dateHuman }}</p>
       {{ end }}
-    </div>
-  </section>
+      <div class="content">
+        {{ .Content }}
+      </div>
+    {{ end }}
+  </div>
 {{ end }}


### PR DESCRIPTION
## What changed

- widen long-form prose from 36rem to 42rem and pair it with an 18px/1.6 reading treatment
- give section landing pages the full site shell instead of the article-width container
- render child-page summaries as responsive cards
- remove the redundant nested `.section` wrapper that doubled page padding, especially on mobile
- use theme-aware link color in section cards

## Why

The default list and single layouts applied the same 576px article container to nearly every page. That kept line length readable, but made landing and index pages look stranded inside large gutters and left useful page width unused.

## Validation

- `hugo --minify --gc` — 123 pages built successfully
- Playwright representative screenshots at mobile, tablet, laptop, and desktop widths in light and dark modes
- Playwright all-page audit: 94 sitemap URLs at 375, 768, 1024, 1366, and 1920px (470 combinations), with zero horizontal overflow or new browser errors

A pre-existing mobile canvas error in the July 2026 Reveal presentation reproduces on the deployed site and is unrelated to this change.