### PR TITLE
feat(ghostkey): send donors back to the app they came from

### DIFF
--- a/hugo-site/content/ghostkey/success/_index.md
+++ b/hugo-site/content/ghostkey/success/_index.md
@@ -14,21 +14,18 @@ without revealing your identity. Please wait a moment while we process your info
 
 ## What's Next?
 
-> **⚠️ Back up first, import second.** The Ghostkey Vault delegate is experimental
-> and can lose keys. **Save your Ghost Key before clicking Import to Freenet.** If
-> the vault loses it and you have no backup, the key and the donation behind it
-> cannot be recovered. Tracked in
-> [freenet/ghostkeys#3](https://github.com/freenet/ghostkeys/issues/3).
+**1. Import to Freenet.** If you have a Freenet peer running on this computer,
+click "Import to Freenet" to add your Ghost Key to your local identity vault.
+Your peer must be running before you click. If you arrived here from an app,
+the vault will offer you the way back once the key has landed.
 
-**1. Backup (do this first):** Download your Ghost Key and save both the certificate
-and the signing key somewhere safe, such as a secure note in a password manager. This
-is currently the authoritative copy of your key. Treat the vault as a convenience, not
-as storage you can rely on.
+**2. Back up when the vault asks.** The vault marks a new identity as
+un-backed-up and shows a reminder next to it, with a one-click download. Do
+that before you rely on the key for anything you would mind losing: on most
+setups the vault holds the only copy, and Freenet is still experimental.
 
-**2. Import to Freenet:** Once you've backed up, if you have a Freenet peer running on
-this computer, click "Import to Freenet" to add your Ghost Key to your local identity
-vault. Your Freenet peer must be running before you click this button. If you lose
-access to your Freenet peer (or the vault loses the key), you can re-import from the
-backup.
+You can also download the certificate and signing key from this page right now
+if you would rather not wait — either copy works, and the vault can re-import
+from one at any time.
 
 {{< bulma-button href="/ghostkey/" color="#339966" >}}Ghost Key FAQ{{< /bulma-button >}}

--- a/hugo-site/static/js/donation-success.js
+++ b/hugo-site/static/js/donation-success.js
@@ -284,7 +284,16 @@ function displayCertificate(armoredCertificate, armoredSigningKey) {
         // Use localhost rather than the literal 127.0.0.1: the node binds its
         // API on the IPv6 loopback by default, so on Windows "localhost" (::1)
         // is reachable while the literal IPv4 address is refused.
-        const importUrl = `http://localhost:7509/v1/contract/web/${contractId}/#import=${certB64}.${skB64}`;
+        // If the donor arrived from an app, hand the vault the way back so it
+        // can offer a one-click return once the key has actually landed.
+        // Re-validated here because it has been through a Stripe redirect;
+        // the vault validates it again and is the authority.
+        const returnTo = new URLSearchParams(window.location.search).get('return_to');
+        const returnFragment =
+          returnTo && /^[1-9A-HJ-NP-Za-km-z]{32,50}$/.test(returnTo)
+            ? `&return_to=${returnTo}`
+            : '';
+        const importUrl = `http://localhost:7509/v1/contract/web/${contractId}/#import=${certB64}.${skB64}${returnFragment}`;
         window.open(importUrl, '_blank');
       });
     }

--- a/hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html
+++ b/hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html
@@ -186,10 +186,24 @@
     event.preventDefault();
     setLoading(true);
 
+    // Carry `return_to` across the Stripe round trip, so the success page can
+    // offer the donor the way back to the app that sent them here. Stripe
+    // preserves the query string on `return_url` and appends its own params.
+    //
+    // Only a syntactically valid Freenet contract id is passed on. The vault
+    // validates it again and independently, and only ever builds a
+    // same-origin `/v1/contract/web/<id>/` path from it, so this is about not
+    // propagating junk rather than about being the security boundary.
+    const returnTo = new URLSearchParams(window.location.search).get('return_to');
+    const returnToParam =
+      returnTo && /^[1-9A-HJ-NP-Za-km-z]{32,50}$/.test(returnTo)
+        ? `?return_to=${encodeURIComponent(returnTo)}`
+        : '';
+
     const { error } = await stripe.confirmPayment({
       elements,
       confirmParams: {
-        return_url: `${window.location.origin}/ghostkey/success`,
+        return_url: `${window.location.origin}/ghostkey/success${returnToParam}`,
       },
     });
 


### PR DESCRIPTION
## Why

From the brief that started this work: *"they might need to leave the site to buy a ghostkey from freenet.org and then navigate back."*

Until now the last step of that round trip was **"find the app again yourself."** An app sends a user here, they pay, they import — and they are standing in their vault with no indication of where they came from. That round trip is the entire cost of choosing Ghost Keys over in-browser proof-of-work, and it was being spent in the worst possible place.

## The change

An app links to:

```
https://freenet.org/ghostkey/create/?return_to=<its contract instance id>
```

The id rides the Stripe redirect on `return_url`, and the success page appends it to the vault import link. Once the key has **actually landed in the delegate**, the vault offers a one-click way back.

The vault half shipped in [ghostkeys#14](https://github.com/freenet/ghostkeys/pull/14) and is live as of the 0.2.4 publish. It parses a **contract id, never a URL**, and re-renders the link from the parsed value, so the only thing it can produce is a same-origin `/v1/contract/web/<id>/` path.

This side re-validates after the Stripe hop and passes on nothing that is not a syntactically valid contract id — about not propagating junk, rather than being the security boundary. Verified against nine inputs including `https://evil.example/steal`, `//evil.example`, `javascript:`, path traversal, and short/long/empty ids.

**When `return_to` is absent or invalid the constructed `return_url` is byte-identical to today's**, which is the case that matters most: nearly every donor arrives without one, and nothing about their flow changes.

## Also: the success page told donors their key might vanish

It opened with a bolded warning to back up *before* importing, because the vault could lose the key. That was accurate when written — the loss was a real bug ([ghostkeys#8](https://github.com/freenet/ghostkeys/issues/8)), now fixed and deployed. Telling someone who has just paid that the thing they bought may disappear is a lot of friction to carry for a bug that no longer exists.

The vault now marks a new identity un-backed-up and shows a reminder with a one-click download **next to the identity itself** — where someone is looking at something they own, rather than standing between them and finishing. The page still offers the immediate download for anyone who would rather not wait.

## Ordering — already satisfied

This could not have merged before the vault was republished. The previously deployed vault parsed the whole fragment after `import=` and split on `.`, so `&return_to=…` landed inside the signing-key field, failed base64 decoding, and the import was **rejected outright**.

Verified against the *currently deployed* vault before opening this, using a deliberately-invalid certificate to see where it fails:

```
Importing ghostkey from URL fragment (cert: 10 bytes, sk: 9 bytes)
Auto-import failed: invalid certificate PEM: …
```

10 and 9 bytes are `not-a-cert` and `not-a-key` decoded cleanly — the fragment was split correctly and the request reached the delegate. The old parser would have failed earlier, at "the signing key could not be decoded".

[AI-assisted - Claude]
