### PR TITLE
feat(ghostkey): carry a return route, not just a contract id

### DIFF
--- a/hugo-site/static/js/donation-success.js
+++ b/hugo-site/static/js/donation-success.js
@@ -288,11 +288,19 @@ function displayCertificate(armoredCertificate, armoredSigningKey) {
         // can offer a one-click return once the key has actually landed.
         // Re-validated here because it has been through a Stripe redirect;
         // the vault validates it again and is the authority.
-        const returnTo = new URLSearchParams(window.location.search).get('return_to');
-        const returnFragment =
-          returnTo && /^[1-9A-HJ-NP-Za-km-z]{32,50}$/.test(returnTo)
-            ? `&return_to=${returnTo}`
-            : '';
+        const params = new URLSearchParams(window.location.search);
+        const returnTo = params.get('return_to');
+        const returnPath = params.get('return_path');
+        let returnFragment = '';
+        if (returnTo && /^[1-9A-HJ-NP-Za-km-z]{32,50}$/.test(returnTo)) {
+          returnFragment = `&return_to=${returnTo}`;
+          // Encoded, because the route may itself contain a `#` for an SPA
+          // route and this whole thing is going into a fragment -- one `#` too
+          // many and the vault's parse breaks.
+          if (returnPath) {
+            returnFragment += `&return_path=${encodeURIComponent(returnPath)}`;
+          }
+        }
         const importUrl = `http://localhost:7509/v1/contract/web/${contractId}/#import=${certB64}.${skB64}${returnFragment}`;
         window.open(importUrl, '_blank');
       });

--- a/hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html
+++ b/hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html
@@ -194,11 +194,20 @@
     // validates it again and independently, and only ever builds a
     // same-origin `/v1/contract/web/<id>/` path from it, so this is about not
     // propagating junk rather than about being the security boundary.
-    const returnTo = new URLSearchParams(window.location.search).get('return_to');
-    const returnToParam =
-      returnTo && /^[1-9A-HJ-NP-Za-km-z]{32,50}$/.test(returnTo)
-        ? `?return_to=${encodeURIComponent(returnTo)}`
-        : '';
+    const params = new URLSearchParams(window.location.search);
+    const returnTo = params.get('return_to');
+    const returnPath = params.get('return_path');
+    let returnToParam = '';
+    if (returnTo && /^[1-9A-HJ-NP-Za-km-z]{32,50}$/.test(returnTo)) {
+      returnToParam = `?return_to=${encodeURIComponent(returnTo)}`;
+      // A route only means anything alongside a contract id, so it rides only
+      // when one is present. The vault validates it again and is the authority
+      // on whether it can escape the contract; this just avoids carrying junk
+      // through a payment flow.
+      if (returnPath) {
+        returnToParam += `&return_path=${encodeURIComponent(returnPath)}`;
+      }
+    }
 
     const { error } = await stripe.confirmPayment({
       elements,


### PR DESCRIPTION
## Why

`?return_to=<id>` landed donors on the app's **root**. An app that sent them off from a deep-linked view got them back with their place lost.

Stripe was never the constraint — it takes a full URL. The limit was the vault end accepting only a bare contract id, which [freenet/ghostkeys#18](https://github.com/freenet/ghostkeys/pull/18) lifts.

## The change

```
/ghostkey/create/?return_to=<contract id>&return_path=<route>
```

The route rides through Stripe and into the vault import fragment, percent-encoded on the way in because it may contain its own `#` for an SPA route and the whole thing is already a fragment.

A route only rides when a contract id is present — one without the other means nothing. The vault validates both again and is the authority on whether a route can escape the contract; this side just avoids carrying junk through a payment flow.

**When neither param is present the constructed `return_url` is unchanged**, which is the case for essentially every donor today.

## Ordering — unlike #98, this one degrades gracefully

#98 had a hard ordering requirement: the old vault parsed the whole fragment after `import=` and a stray `&return_to=` broke the import outright.

This one does not. The deployed vault splits the fragment on `&` and looks for the params it knows, so an unrecognised `return_path=` is simply ignored. Verified against the **currently deployed** vault with a deliberately-invalid certificate, to see how far it gets:

```
Importing ghostkey from URL fragment (cert: 10 bytes, sk: 9 bytes)
Auto-import failed: invalid certificate PEM: …
```

Byte-for-byte the same decode as a link *without* `return_path` — the extra param cost nothing. So merging this before ghostkeys#18 publishes is safe; donors would simply land on the app root until the new vault ships, which is exactly today's behaviour.

[AI-assisted - Claude]
