### PR TITLE
feat(ghostkey): extend the donation ladder to $500 / $2,500 / $10,000

### DIFF
--- a/hugo-site/content/ghostkey/_index.md
+++ b/hugo-site/content/ghostkey/_index.md
@@ -195,20 +195,32 @@ For developers, everything is open source:
 
 ## How much should I donate?
 
-The minimum is **$1**. Donate as much as you can; the amount is recorded in your
-certificate, so apps that want to grant additional privileges to larger donors can do
-so.
+The minimum is **$1** and the maximum is **$10,000**. Donate as much as you can; the
+amount is recorded in your certificate, so apps that want to grant additional privileges
+to larger donors can do so.
+
+Card issuers commonly decline single charges in the thousands, so the two largest tiers
+may not go through on an ordinary consumer card. A decline costs you nothing — no charge
+is made and no key is issued — so it is safe to try one and fall back to a smaller
+amount.
 
 ### Why the amounts are fixed
 
-You choose from $1, $5, $20, $50, or $100 rather than typing your own figure, and that
-is a privacy decision rather than a limitation we haven't got around to lifting.
+You choose from $1, $5, $20, $50, $100, $500, $2,500, or $10,000 rather than typing your
+own figure, and that is a privacy decision rather than a limitation we haven't got around
+to lifting.
 
 The donation amount is written into your certificate, so anyone who verifies it can read
 it. Fixed tiers mean your certificate is indistinguishable from every other certificate
-issued at the same amount: the amount tells an observer which of five groups you are in
+issued at the same amount: the amount tells an observer which of eight groups you are in
 and nothing more. A free-form amount like $37.42 would be close to unique, and would
 give away much of what blind signing is there to protect.
+
+The same logic applies to the tiers themselves: the larger ones will have fewer holders,
+so a certificate at the top of the range says more about you than one at the bottom.
+Nobody outside the Freenet Project can turn that into a name — doing so needs the
+payment records, which never leave us and are never linked to a certificate — but if you
+want the largest possible crowd to hide in, the lower tiers are where it is.
 
 <div class="gk-cta">
 <a href="/ghostkey/create/" class="funding-donate-button">Get a Ghost Key</a>

--- a/hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html
+++ b/hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html
@@ -10,6 +10,11 @@
          into the certificate and is visible to anyone who verifies it, so a
          free-form amount would be near-unique. Do not add a custom-amount field.
 
+         The high tiers ($2,500 and $10,000) exceed what many consumer cards
+         will authorise. That is a clean decline with no charge, not a
+         charged-without-a-key failure, but expect a proportion of attempts on
+         those two to fail at the card step.
+
          If you change this list, update the prose that names the tiers in
          hugo-site/content/ghostkey/_index.md ("Why the amounts are fixed").
 
@@ -21,6 +26,9 @@
         <label class="donation-amount-label"><input type="radio" name="amount" value="20"> $20</label>
         <label class="donation-amount-label"><input type="radio" name="amount" value="50"> $50</label>
         <label class="donation-amount-label"><input type="radio" name="amount" value="100"> $100</label>
+        <label class="donation-amount-label"><input type="radio" name="amount" value="500"> $500</label>
+        <label class="donation-amount-label"><input type="radio" name="amount" value="2500"> $2,500</label>
+        <label class="donation-amount-label"><input type="radio" name="amount" value="10000"> $10,000</label>
     </div>
     <div id="payment-element" style="margin-bottom: 20px;">
       <!-- Stripe Elements will be inserted here -->


### PR DESCRIPTION
> **Draft on purpose. Merging this before the notary keypairs exist on the API host will charge donors and give them nothing.**

The maximum was $100, which is low for anyone who wants to give substantially — and the amount is the only thing an app can condition on. Adds three tiers keeping the exponential shape: **$1 / $5 / $20 / $50 / $100 / $500 / $2,500 / $10,000**.

## The blocking step

`get_notary(amount)` reads `notary_certificate_{amount}.pem` and `notary_signing_key_{amount}.pem` from `$NOTARY_DIR`. **There is no server-side allowlist of amounts** — the only thing making a tier work is that its keypair is on disk. Ship a button first and the card is charged, then certificate signing fails, and the donor is paid up with no key. That is the worst failure available in this flow.

The existing script does it correctly — right `info` JSON (including the `delegate-key-created` field that must never be renamed), per-amount rename, 0600, and it refuses to overwrite existing tiers so the current five cannot be clobbered:

```bash
rust/cli/generate_notary_keys.sh --master-key <master_signing_key.pem> \
    --amounts 500 2500 10000
```

Then the six new files need to reach `$NOTARY_DIR` on the API host. **Merge only after that is confirmed** — ideally after a live $500 purchase end to end, since that is the cheapest of the three to test with real money.

## The anonymity cost, stated rather than buried

Larger tiers will have fewer holders, so a certificate at the top of the range narrows its holder to a smaller group than one at the bottom. That group cannot be turned into a name without the payment records, which only the Freenet Project holds and which are never linked to a certificate — so it is a record-retention property, not a weakness in the design.

The page now says this plainly, and points anyone who wants the largest crowd to hide in at the lower tiers. It seemed wrong to add tiers that carry a privacy cost without telling people it exists.

## The top two will often decline

$2,500 and $10,000 exceed what many consumer cards authorise. That is a clean decline with **no charge** — not a charged-without-a-key failure — and the page says so, so it is safe to try one and fall back.

## Not changed

- No custom-amount field. Free-form amounts are near-unique in a certificate and would give away most of what blind signing protects.
- `rust/integration_test` selects the `$20` radio, which is untouched.

[AI-assisted - Claude]