### PR TITLE
fix(faq): repair dead anchor links and gate them in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,6 +98,12 @@ jobs:
           echo "Contents of hugo-site/public/wasm:"
           ls -la hugo-site/public/wasm
 
+      # Catch dead internal links and #anchors before they reach freenet.org.
+      # Hugo does not validate fragments, so a deleted section silently leaves
+      # every link to it broken.
+      - name: Check internal links
+        run: cargo make check-links
+
       # Upload the built site to GitHub Pages artifact
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/publish-freenet.yml
+++ b/.github/workflows/publish-freenet.yml
@@ -31,6 +31,17 @@ jobs:
       - name: Install cargo-make
         run: cargo install --debug cargo-make
 
+      # Same content ships here as to GitHub Pages, so gate it on the same
+      # link check. This runs against an ordinary build: `cargo make
+      # build-freenet` rewrites every path for the contract baseURL and
+      # deletes the server-dependent directories, so its output is expected
+      # to contain dangling links and is not comparable.
+      # Placed before `cargo install fdev` so a bad link fails fast.
+      - name: Check internal links
+        run: |
+          (cd hugo-site && hugo --minify)
+          cargo make check-links
+
       - name: Install fdev
         run: cargo install fdev
         env:

--- a/.github/workflows/publish-freenet.yml
+++ b/.github/workflows/publish-freenet.yml
@@ -31,12 +31,23 @@ jobs:
       - name: Install cargo-make
         run: cargo install --debug cargo-make
 
-      # Same content ships here as to GitHub Pages, so gate it on the same
-      # link check. This runs against an ordinary build: `cargo make
-      # build-freenet` rewrites every path for the contract baseURL and
-      # deletes the server-dependent directories, so its output is expected
-      # to contain dangling links and is not comparable.
-      # Placed before `cargo install fdev` so a bad link fails fast.
+      # This publishes the same *content* as deploy.yml, so gate it on the
+      # same link check: otherwise a broken anchor stops GitHub Pages while
+      # the contract still takes the new content, and the two mirrors
+      # silently diverge.
+      #
+      # Checks an ordinary build rather than `cargo make build-freenet`'s
+      # output, which rewrites every path for the contract baseURL and
+      # deletes the directories that need a server (/wasm, /ghostkey,
+      # /slides) — dangling links there are expected, so it cannot be
+      # compared against. That makes this a proxy for what ships, and the
+      # proxy differs in one known way: /wasm is absent here (it is
+      # gitignored and only deploy.yml builds it), which is what the
+      # contract gets anyway since build-freenet deletes it.
+      #
+      # Runs before `cargo install fdev` so a bad link fails in seconds
+      # rather than after a ~9 minute install, and before the signing key is
+      # written to disk.
       - name: Check internal links
         run: |
           (cd hugo-site && hugo --minify)

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Cargo.lock
 rust/browser-extension/node_modules
 rust/browser-extension/dist
 rust/browser-extension/wasm
+
+# Python bytecode from scripts/
+__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ cargo make build-site             # Prepare deployment artifacts
 cargo make integration-test
 ./test_cli_commands.sh
 cargo test --all
+cargo make check-links       # broken internal links / dead #anchors (needs hugo-site/public)
 ```
 
 ### Linting & Formatting

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -42,6 +42,13 @@ echo "Contents of public/wasm after running hugo:"
 ls -la public/wasm
 """
 
+[tasks.check-links]
+description = "Fail if the built site has broken internal links or dead #anchors"
+script = """
+python3 scripts/check-links.py --self-test
+python3 scripts/check-links.py hugo-site/public
+"""
+
 [tasks.build-wasm-dev]
 description = "Build WebAssembly in development mode"
 script = """

--- a/hugo-site/content/about/faq/index.md
+++ b/hugo-site/content/about/faq/index.md
@@ -2,28 +2,16 @@
 title: "Frequently Asked Questions"
 date: 2024-06-24
 draft: false
+summary: >-
+  Common questions about Freenet: what it is, how it works, how it relates to the original Freenet,
+  and how to support the project.
 aliases:
   - /faq/
 ---
 
 {{< toc >}}
 
-- [What is Freenet?](#what-is-freenet)
-- [How does Freenet work?](#how-does-freenet-work)
-- [What is the project's history?](#what-is-the-projects-history)
-- [How do the previous and current versions of Freenet differ?](#how-do-the-previous-and-current-versions-of-freenet-differ)
-- [Does Freenet provide anonymity like Tor or I2P?](#does-freenet-provide-anonymity-like-tor-or-i2p)
-- [Will the new Freenet be backwards compatible with the old Freenet?](#will-the-new-freenet-be-backwards-compatible-with-the-old-freenet)
-- [Why was Freenet rearchitected and rebranded?](#why-was-freenet-rearchitected-and-rebranded)
-- [How does Freenet compare to other decentralized systems?](#how-does-freenet-compare-to-other-decentralized-systems)
-- [Does Freenet have decentralized domain names or DNS?](#does-freenet-have-decentralized-domain-names-or-dns)
-- [Who is behind Freenet?](#who-is-behind-freenet)
-- [How does Freenet handle harmful content?](#how-does-freenet-handle-harmful-content)
-- [What is the status of Freenet?](#what-is-the-status-of-freenet)
-- [Can I follow Freenet on social media?](#can-i-follow-freenet-on-social-media)
-- [How can I financially support Freenet development?](#how-can-i-financially-support-freenet-development)
-- [How do I uninstall Freenet?](#how-do-i-uninstall-freenet)
-- [Why does the Freenet project use and mention AI tools?](#why-does-the-freenet-project-use-and-mention-ai-tools)
+# What is Freenet? {#what-is-freenet}
 
 Freenet is a fully decentralized, peer-to-peer network and a drop-in replacement for the world wide
 web. It operates as a global shared computer, providing a platform for sophisticated decentralized

--- a/hugo-site/content/about/history/index.md
+++ b/hugo-site/content/about/history/index.md
@@ -2,6 +2,9 @@
 title: "Freenet's History"
 date: 2024-06-24
 draft: false
+summary: >-
+  Freenet's 25-year history, and how the projects that grew out of the original
+  1999 release relate to each other.
 aliases:
   - /resources/history/
 ---

--- a/hugo-site/content/about/news/456-mitigating-sybil-attacks-in-freenet.md
+++ b/hugo-site/content/about/news/456-mitigating-sybil-attacks-in-freenet.md
@@ -30,9 +30,10 @@ close to that location.
 
 # Solutions
 
-1. [Increase the cost of creating a large number of nodes close to a specific chosen identities](#identity-creation-cost)
-2. [Make it more difficult to target specific contracts](#location-hopping)
-3. [Increase the cost of bad behavior by making other nodes in the network monitor for it and react accordingly](#peer-pressure)
+1. [Increase the cost of creating a large number of nodes close to a specific chosen identities](#1-identity-creation-cost)
+2. [Make it more difficult to target specific contracts](#2-location-hopping)
+3. Increase the cost of bad behavior by making other nodes in the network monitor for it and react
+   accordingly
 4. [Use statistical anomaly detection to identify and thwart suspicious behavior](https://www.pivotaltracker.com/story/show/186472381)
 
 ## 1. Identity Creation Cost

--- a/hugo-site/content/about/news/456-mitigating-sybil-attacks-in-freenet.md
+++ b/hugo-site/content/about/news/456-mitigating-sybil-attacks-in-freenet.md
@@ -34,7 +34,7 @@ close to that location.
 2. [Make it more difficult to target specific contracts](#2-location-hopping)
 3. Increase the cost of bad behavior by making other nodes in the network monitor for it and react
    accordingly
-4. [Use statistical anomaly detection to identify and thwart suspicious behavior](https://www.pivotaltracker.com/story/show/186472381)
+4. Use statistical anomaly detection to identify and thwart suspicious behavior
 
 ## 1. Identity Creation Cost
 

--- a/hugo-site/content/build/manual/_index.md
+++ b/hugo-site/content/build/manual/_index.md
@@ -3,6 +3,9 @@ title: "Freenet Manual"
 date: 2025-04-13
 draft: false
 layout: "single"
+summary: >-
+  Comprehensive documentation on Freenet's components, architecture, developer guide, client SDKs,
+  and reference material.
 aliases:
   - /resources/manual/
   - /manual/

--- a/hugo-site/content/community/get-involved.md
+++ b/hugo-site/content/community/get-involved.md
@@ -1,7 +1,0 @@
----
-title: "Community"
-date: 2024-06-11T00:00:00Z
-draft: false
----
-
-Connect with us through the following platforms:

--- a/hugo-site/hugo.toml
+++ b/hugo-site/hugo.toml
@@ -146,10 +146,6 @@ theme = "freenet"
   posts = "/:year/:month/:title/"
 
 [markup]
-  [markup.tableOfContents]
-    startLevel = 1
-    endLevel = 3
-
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true

--- a/hugo-site/hugo.toml
+++ b/hugo-site/hugo.toml
@@ -146,6 +146,10 @@ theme = "freenet"
   posts = "/:year/:month/:title/"
 
 [markup]
+  [markup.tableOfContents]
+    startLevel = 1
+    endLevel = 3
+
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true

--- a/hugo-site/themes/freenet/layouts/_default/list.html
+++ b/hugo-site/themes/freenet/layouts/_default/list.html
@@ -18,8 +18,12 @@
               {{/* Strip links: an auto-summary carries the child page's own
                    hrefs, and a page-relative one ("#section", "introduction")
                    resolves against THIS page instead, so it lands nowhere.
-                   The card title already links to the page. */}}
-              {{ .Summary | replaceRE `</?a[^>]*>` "" | safeHTML }}
+                   The card title already links to the page.
+                   The pattern matches <a>/</a> only — the \s guard keeps it
+                   off <abbr>, <address>, <article>, <audio>, and the quoted
+                   alternatives keep a ">" inside an attribute value from
+                   ending the match early. */}}
+              {{ .Summary | replaceRE `</?a(?:\s(?:"[^"]*"|'[^']*'|[^>])*)?>` "" | safeHTML }}
             </div>
           </section>
         {{ end }}

--- a/hugo-site/themes/freenet/layouts/_default/list.html
+++ b/hugo-site/themes/freenet/layouts/_default/list.html
@@ -15,15 +15,12 @@
               <p class="date">{{ .Date.Format "2 January, 2006" }}</p>
             {{ end }}
             <div class="content">
-              {{/* Strip links: an auto-summary carries the child page's own
-                   hrefs, and a page-relative one ("#section", "introduction")
-                   resolves against THIS page instead, so it lands nowhere.
-                   The card title already links to the page.
-                   The pattern matches <a>/</a> only — the \s guard keeps it
-                   off <abbr>, <address>, <article>, <audio>, and the quoted
-                   alternatives keep a ">" inside an attribute value from
-                   ending the match early. */}}
-              {{ .Summary | replaceRE `</?a(?:\s(?:"[^"]*"|'[^']*'|[^>])*)?>` "" | safeHTML }}
+              {{/* An auto-summary carries the child page's own hrefs, and a
+                   page-relative one ("#section", "introduction") resolves
+                   against THIS page instead, so it lands nowhere. Give such a
+                   page an explicit `summary:` in its front matter; scripts/
+                   check-links.py fails the build if one slips through. */}}
+              {{ .Summary }}
             </div>
           </section>
         {{ end }}

--- a/hugo-site/themes/freenet/layouts/_default/list.html
+++ b/hugo-site/themes/freenet/layouts/_default/list.html
@@ -15,7 +15,11 @@
               <p class="date">{{ .Date.Format "2 January, 2006" }}</p>
             {{ end }}
             <div class="content">
-              {{ .Summary }}
+              {{/* Strip links: an auto-summary carries the child page's own
+                   hrefs, and a page-relative one ("#section", "introduction")
+                   resolves against THIS page instead, so it lands nowhere.
+                   The card title already links to the page. */}}
+              {{ .Summary | replaceRE `</?a[^>]*>` "" | safeHTML }}
             </div>
           </section>
         {{ end }}

--- a/hugo-site/themes/freenet/layouts/_default/single.html
+++ b/hugo-site/themes/freenet/layouts/_default/single.html
@@ -35,7 +35,8 @@
           <p class="date">{{ .Date.Format "2 January, 2006" }}</p>
         {{ end }}
         <div class="content">
-          {{ .Summary }}
+          {{/* Links stripped for the same reason as in _default/list.html. */}}
+          {{ .Summary | replaceRE `</?a[^>]*>` "" | safeHTML }}
         </div>
       {{ end }}
     </div>

--- a/hugo-site/themes/freenet/layouts/_default/single.html
+++ b/hugo-site/themes/freenet/layouts/_default/single.html
@@ -36,7 +36,7 @@
         {{ end }}
         <div class="content">
           {{/* Links stripped for the same reason as in _default/list.html. */}}
-          {{ .Summary | replaceRE `</?a[^>]*>` "" | safeHTML }}
+          {{ .Summary | replaceRE `</?a(?:\s(?:"[^"]*"|'[^']*'|[^>])*)?>` "" | safeHTML }}
         </div>
       {{ end }}
     </div>

--- a/hugo-site/themes/freenet/layouts/_default/single.html
+++ b/hugo-site/themes/freenet/layouts/_default/single.html
@@ -35,8 +35,8 @@
           <p class="date">{{ .Date.Format "2 January, 2006" }}</p>
         {{ end }}
         <div class="content">
-          {{/* Links stripped for the same reason as in _default/list.html. */}}
-          {{ .Summary | replaceRE `</?a(?:\s(?:"[^"]*"|'[^']*'|[^>])*)?>` "" | safeHTML }}
+          {{/* See the note on .Summary in _default/list.html. */}}
+          {{ .Summary }}
         </div>
       {{ end }}
     </div>

--- a/hugo-site/themes/freenet/layouts/shortcodes/toc.html
+++ b/hugo-site/themes/freenet/layouts/shortcodes/toc.html
@@ -1,1 +1,1 @@
-{{ .Page.TableOfContents }}
+{{ .Page.Fragments.ToHTML 1 3 false }}

--- a/hugo-site/themes/freenet/layouts/shortcodes/toc.html
+++ b/hugo-site/themes/freenet/layouts/shortcodes/toc.html
@@ -1,11 +1,1 @@
-{{ $headings := .Page.Content | markdownify | plainify | findRE "(?m)^# (.+)$" }}
-<ul>
-{{ range $headings }}
-  {{ $heading := index . 1 }}
-  {{ if eq $heading "Why was Freenet rearchitected and rebranded?" }}
-    <li><a href="#faq-5">{{ $heading }}</a></li>
-  {{ else }}
-    <li><a href="#{{ $heading | urlize }}">{{ $heading }}</a></li>
-  {{ end }}
-{{ end }}
-</ul>
+{{ .Page.TableOfContents }}

--- a/scripts/check-links.py
+++ b/scripts/check-links.py
@@ -4,7 +4,7 @@
 Usage: python3 scripts/check-links.py [output-dir]
        python3 scripts/check-links.py --self-test
 
-Checks every ``<a href>`` in the built HTML for two failure modes:
+Checks every same-site reference in the built HTML for two failure modes:
 
 * the target page or file does not exist in the output, and
 * the target page exists but has no element with the ``#fragment`` id.
@@ -14,8 +14,9 @@ The second one is what motivated this script: a FAQ entry was deleted in March
 ``/about/faq/#what-is-the-status-of-freenet`` pointed at nothing for a year
 before a user reported it. Hugo does not verify fragments, and neither did CI.
 
-Only same-site links are checked. External URLs are left alone so the check
-stays deterministic and offline.
+Links to other sites are left alone so the check stays deterministic and
+offline. The site's own hostname is read from the generated sitemap, so a build
+with a non-default ``baseURL`` is still checked rather than silently skipped.
 """
 
 import os
@@ -24,44 +25,108 @@ import sys
 import urllib.parse
 from html.parser import HTMLParser
 
-# Links whose target lives outside the built output. Everything else that
-# resolves to this site must exist.
-INTERNAL_HOSTS = {"", "freenet.org", "www.freenet.org"}
+# The production hostnames. Content links to these absolutely, so they count as
+# internal whatever baseURL a particular build used; whatever host the build
+# itself emitted is added to this set at run time (see site_hosts).
+PRODUCTION_HOSTS = {"freenet.org", "www.freenet.org"}
 
-# Hugo writes alias pages as a stub with a meta refresh; follow those so a
-# fragment link through an alias is checked against the real page.
-REFRESH_RE = re.compile(
-    r"""<meta[^>]+http-equiv=["']?refresh["']?[^>]*""" r"""content=["'][^"']*?url=([^"'\s]+)""",
-    re.IGNORECASE,
-)
+# Attributes that name something which has to exist in the output. Anchors are
+# the reason this script exists, but a missing image or stylesheet is just as
+# user-visible and just as invisible to Hugo.
+REFERENCE_ATTRS = {
+    "a": ("href",),
+    "area": ("href",),
+    "audio": ("src",),
+    "embed": ("src",),
+    "iframe": ("src",),
+    "img": ("src", "srcset"),
+    "link": ("href",),
+    "object": ("data",),
+    "script": ("src",),
+    "source": ("src", "srcset"),
+    "track": ("src",),
+    "video": ("poster", "src"),
+}
+
+# "top" always scrolls to the top of the document, with or without a matching
+# element. https://html.spec.whatwg.org/multipage/browsing-the-web.html#scrolling-to-a-fragment
+ALWAYS_VALID_FRAGMENTS = {"top"}
+
 MAX_REDIRECTS = 5
+
+# <meta http-equiv=refresh content="0; url=..."> — only meaningful in <head>,
+# which is where Hugo puts it for an alias page.
+REFRESH_URL_RE = re.compile(r"""url\s*=\s*['"]?([^'";\s]+)""", re.IGNORECASE)
+
+SITEMAP_LOC_RE = re.compile(r"<loc>\s*([^<\s]+)\s*</loc>", re.IGNORECASE)
+
+
+def first_attr(attrs):
+    """Fold a parsed attribute list into a dict, keeping the FIRST of any
+    duplicate, which is the one a browser honours."""
+    folded = {}
+    for name, value in attrs:
+        name = name.lower()
+        if name not in folded:
+            folded[name] = value
+    return folded
 
 
 class PageParser(HTMLParser):
-    """Collect the anchor ids a page defines and the links it makes."""
+    """Collect the anchor ids a page defines and the references it makes."""
 
     def __init__(self):
         super().__init__(convert_charrefs=True)
         self.ids = set()
-        self.hrefs = []
+        self.references = []
+        self.redirect_to = None
+        self._in_head = False
 
     def handle_starttag(self, tag, attrs):
-        attrs = dict(attrs)
+        tag = tag.lower()
+        attrs = first_attr(attrs)
+
+        if tag == "head":
+            self._in_head = True
+        elif tag == "body":
+            self._in_head = False
+
         if attrs.get("id"):
             self.ids.add(attrs["id"])
-        if tag == "a":
-            # Pre-HTML5 named anchors are still valid fragment targets.
-            if attrs.get("name"):
-                self.ids.add(attrs["name"])
-            if attrs.get("href") is not None:
-                self.hrefs.append(attrs["href"])
+        # Pre-HTML5 named anchors are still valid fragment targets.
+        if tag == "a" and attrs.get("name"):
+            self.ids.add(attrs["name"])
 
+        # Hugo writes alias pages as a meta-refresh stub. Only honour one in
+        # <head>: a manual page may legitimately *document* a refresh tag, and
+        # treating that page as a redirect would send fragment checks
+        # somewhere else entirely.
+        if (
+            tag == "meta"
+            and self._in_head
+            and self.redirect_to is None
+            and (attrs.get("http-equiv") or "").strip().lower() == "refresh"
+        ):
+            match = REFRESH_URL_RE.search(attrs.get("content") or "")
+            if match:
+                self.redirect_to = match.group(1)
 
-class Page:
-    def __init__(self, ids, hrefs, redirect_to):
-        self.ids = ids
-        self.hrefs = hrefs
-        self.redirect_to = redirect_to
+        for attr in REFERENCE_ATTRS.get(tag, ()):
+            value = attrs.get(attr)
+            if not value:
+                continue
+            if attr == "srcset":
+                # "a.png 1x, b.png 2x" -> each candidate URL
+                for candidate in value.split(","):
+                    candidate = candidate.strip().split()
+                    if candidate:
+                        self.references.append(candidate[0])
+            else:
+                self.references.append(value)
+
+    def handle_endtag(self, tag):
+        if tag.lower() == "head":
+            self._in_head = False
 
 
 def load_pages(root):
@@ -76,11 +141,29 @@ def load_pages(root):
                 source = handle.read()
             parser = PageParser()
             parser.feed(source)
-            match = REFRESH_RE.search(source)
-            redirect_to = match.group(1) if match else None
+            parser.close()
             key = "/" + os.path.relpath(path, root).replace(os.sep, "/")
-            pages[key] = Page(parser.ids, parser.hrefs, redirect_to)
+            pages[key] = parser
     return pages
+
+
+def site_hosts(root):
+    """The hostnames that mean "this site".
+
+    Hugo stamps the configured baseURL into sitemap.xml, so reading it back
+    keeps the check honest for a build published under a different host
+    instead of silently treating its own links as external.
+    """
+    hosts = set(PRODUCTION_HOSTS)
+    sitemap = os.path.join(root, "sitemap.xml")
+    if os.path.isfile(sitemap):
+        with open(sitemap, encoding="utf-8", errors="replace") as handle:
+            match = SITEMAP_LOC_RE.search(handle.read())
+        if match:
+            hostname = urllib.parse.urlparse(match.group(1)).hostname
+            if hostname:
+                hosts.add(hostname.lower())
+    return hosts
 
 
 def page_key(pages, path):
@@ -95,56 +178,77 @@ def page_key(pages, path):
 
 
 def follow_redirects(pages, key):
-    """Chase meta-refresh alias stubs to the page that actually has content."""
+    """Chase meta-refresh alias stubs to the page that actually has content.
+
+    Returns ``(key, None)`` on success or ``(None, reason)`` if the chain does
+    not land anywhere real.
+    """
     seen = set()
-    for _ in range(MAX_REDIRECTS):
+    while True:
         page = pages[key]
-        if not page.redirect_to or key in seen:
-            return key
+        if not page.redirect_to:
+            return key, None
+        if key in seen:
+            return None, "redirect loop"
+        if len(seen) >= MAX_REDIRECTS:
+            return None, "redirect chain longer than %d hops" % MAX_REDIRECTS
         seen.add(key)
-        target = urllib.parse.urlparse(urllib.parse.urljoin("https://freenet.org" + key, page.redirect_to))
-        if target.netloc not in INTERNAL_HOSTS:
-            return None
+        target = urllib.parse.urlparse(
+            urllib.parse.urljoin("https://site.invalid" + key, page.redirect_to)
+        )
         next_key = page_key(pages, target.path)
         if next_key is None:
-            return None
+            return None, "redirect target does not exist"
         key = next_key
-    return key
 
 
 def check(root):
-    """Return a list of ``(page, href, reason)`` for every broken link found."""
+    """Return ``(page_count, broken)`` where broken is a list of
+    ``(page, reference, reason)``."""
     pages = load_pages(root)
+    hosts = site_hosts(root)
     broken = []
     for source_key, page in sorted(pages.items()):
-        for href in page.hrefs:
+        for reference in page.references:
             url = urllib.parse.urlparse(
-                urllib.parse.urljoin("https://freenet.org" + source_key, href)
+                urllib.parse.urljoin("https://" + sorted(hosts)[0] + source_key, reference)
             )
-            if url.scheme not in ("http", "https") or url.netloc not in INTERNAL_HOSTS:
-                continue  # mailto:, external site, protocol-relative CDN, ...
+            if url.scheme not in ("http", "https"):
+                continue  # mailto:, data:, javascript:, ...
+            if (url.hostname or "").lower() not in hosts:
+                continue  # another site; not ours to verify
             fragment = urllib.parse.unquote(url.fragment)
+            path = urllib.parse.unquote(url.path)
+
             target_key = page_key(pages, url.path)
             if target_key is None:
-                # Not a page; it may still be a static file such as a PDF.
-                on_disk = os.path.join(root, urllib.parse.unquote(url.path).lstrip("/"))
-                if not os.path.exists(on_disk):
-                    broken.append((source_key, href, "target does not exist"))
+                # Not a page, so it has to be a file that exists — a directory
+                # with no index.html is a 404, not a valid target.
+                if not os.path.isfile(os.path.join(root, path.lstrip("/"))):
+                    broken.append((source_key, reference, "target does not exist"))
                 continue
-            if not fragment:
+
+            if not fragment or fragment in ALWAYS_VALID_FRAGMENTS:
                 continue
-            resolved = follow_redirects(pages, target_key)
+            # Check the page's own ids before following any redirect: a real
+            # page can carry a meta refresh and still be the fragment's home.
+            if fragment in pages[target_key].ids:
+                continue
+            resolved, reason = follow_redirects(pages, target_key)
             if resolved is None:
-                broken.append((source_key, href, "redirect target does not exist"))
+                broken.append((source_key, reference, reason))
             elif fragment not in pages[resolved].ids:
-                broken.append((source_key, href, "no #%s on the target page" % fragment))
+                broken.append((source_key, reference, "no #%s on the target page" % fragment))
     return len(pages), broken
 
 
 def report(root):
     total, broken = check(root)
-    for source_key, href, reason in broken:
-        print("%s -> %s: %s" % (source_key, href, reason), file=sys.stderr)
+    if total == 0:
+        print("No HTML pages found in %s (build the site first)" % root, file=sys.stderr)
+        return 2
+    for source_key, reference, reason in broken:
+        print("%s -> %s: %s" % (source_key, reference, reason), file=sys.stderr)
     if broken:
         print(
             "\n%d broken internal link(s) across %d page(s)." % (len(broken), total),
@@ -159,13 +263,15 @@ def self_test():
     """Prove the checker actually fails on the bugs it claims to catch.
 
     A link checker that silently stops checking is worse than none at all, so
-    CI runs this before trusting a clean report on the real site.
+    CI runs this before trusting a clean report on the real site. Every case
+    below is one a previous version of this script got wrong.
     """
     import shutil
     import tempfile
 
     root = tempfile.mkdtemp(prefix="check-links-selftest-")
     try:
+
         def write(path, body):
             full = os.path.join(root, path)
             os.makedirs(os.path.dirname(full), exist_ok=True)
@@ -180,32 +286,75 @@ def self_test():
             <a href="#deleted-section">BAD fragment</a>
             <a name="legacy-anchor"></a>
             <a href="#legacy-anchor">good named anchor</a>
+            <a href="#top">good: #top always resolves</a>
             <a href="/about/">good page</a>
             <a href="/nope/">BAD page</a>
             <a href="/paper.pdf">good static file</a>
             <a href="/missing.pdf">BAD static file</a>
+            <a href="/assets/">BAD: directory with no index.html</a>
+            <img src="/logo.png">
+            <img src="/missing.png">
+            <img srcset="/logo.png 1x, /missing-2x.png 2x">
+            <link rel="stylesheet" href="/site.css">
+            <script src="/missing.js"></script>
             <a href="https://example.com/#whatever">external, not checked</a>
             <a href="mailto:x@example.com">mailto, not checked</a>
             <a href="/old-faq/#what-is-freenet">good through alias</a>
             <a href="/old-faq/#gone">BAD through alias</a>
+            <a href="/loop-a/#anything">BAD: redirect loop</a>
+            <a href="/documented/#really-here">good: refresh in body is not an alias</a>
+            <a href="/body-refresh/#what-is-freenet">BAD: body refresh is not an alias to follow</a>
+            <a href="/dup-attr/" href="/about/">BAD: a browser honours the first href</a>
+            <a href="HTTPS://FREENET.ORG/nope/">BAD: uppercase host is still us</a>
+            <a href="https://freenet.org:443/nope/">BAD: default port is still us</a>
             """,
         )
         write("about/index.html", "<p>hi</p>")
+        write("old-faq/index.html", '<head><meta http-equiv="refresh" content="0; url=/faq/"></head>')
+        write("loop-a/index.html", '<head><meta http-equiv="refresh" content="0; url=/loop-b/"></head>')
+        write("loop-b/index.html", '<head><meta http-equiv="refresh" content="0; url=/loop-a/"></head>')
+        # A real page that merely *documents* a meta refresh must not be
+        # mistaken for an alias stub.
         write(
-            "old-faq/index.html",
-            '<meta http-equiv="refresh" content="0; url=/faq/">',
+            "documented/index.html",
+            "<head><title>t</title></head><body><h2 id=really-here>x</h2>"
+            "<pre>&lt;meta http-equiv=\"refresh\" content=\"0; url=/faq/\"&gt;</pre></body>",
+        )
+        # A refresh tag outside <head> does not make the page an alias, so a
+        # fragment must be found on the page itself, not on the refresh target.
+        write(
+            "body-refresh/index.html",
+            '<head><title>t</title></head><body><meta http-equiv="refresh" '
+            'content="0; url=/faq/"><p>real content</p></body>',
         )
         write("paper.pdf", "%PDF-1.4")
+        write("logo.png", "PNG")
+        write("site.css", "body{}")
+        write("assets/keep.txt", "not an index")
 
         _total, broken = check(root)
-        found = sorted(href for _src, href, _reason in broken)
+        found = sorted(reference for _src, reference, _reason in broken)
         expected = sorted(
-            ["#deleted-section", "/nope/", "/missing.pdf", "/old-faq/#gone"]
+            [
+                "#deleted-section",
+                "/nope/",
+                "/missing.pdf",
+                "/assets/",
+                "/missing.png",
+                "/missing-2x.png",
+                "/missing.js",
+                "/old-faq/#gone",
+                "/loop-a/#anything",
+                "/body-refresh/#what-is-freenet",
+                "/dup-attr/",
+                "HTTPS://FREENET.ORG/nope/",
+                "https://freenet.org:443/nope/",
+            ]
         )
         if found != expected:
             print("self-test FAILED", file=sys.stderr)
-            print("  expected: %s" % expected, file=sys.stderr)
-            print("  found:    %s" % found, file=sys.stderr)
+            print("  missing: %s" % sorted(set(expected) - set(found)), file=sys.stderr)
+            print("  unexpected: %s" % sorted(set(found) - set(expected)), file=sys.stderr)
             return 1
         print("self-test passed (%d expected failures detected)" % len(expected))
         return 0

--- a/scripts/check-links.py
+++ b/scripts/check-links.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Fail the build if the generated site contains a broken internal link.
+
+Usage: python3 scripts/check-links.py [output-dir]
+       python3 scripts/check-links.py --self-test
+
+Checks every ``<a href>`` in the built HTML for two failure modes:
+
+* the target page or file does not exist in the output, and
+* the target page exists but has no element with the ``#fragment`` id.
+
+The second one is what motivated this script: a FAQ entry was deleted in March
+2025 but its table-of-contents link was left behind, so
+``/about/faq/#what-is-the-status-of-freenet`` pointed at nothing for a year
+before a user reported it. Hugo does not verify fragments, and neither did CI.
+
+Only same-site links are checked. External URLs are left alone so the check
+stays deterministic and offline.
+"""
+
+import os
+import re
+import sys
+import urllib.parse
+from html.parser import HTMLParser
+
+# Links whose target lives outside the built output. Everything else that
+# resolves to this site must exist.
+INTERNAL_HOSTS = {"", "freenet.org", "www.freenet.org"}
+
+# Hugo writes alias pages as a stub with a meta refresh; follow those so a
+# fragment link through an alias is checked against the real page.
+REFRESH_RE = re.compile(
+    r"""<meta[^>]+http-equiv=["']?refresh["']?[^>]*""" r"""content=["'][^"']*?url=([^"'\s]+)""",
+    re.IGNORECASE,
+)
+MAX_REDIRECTS = 5
+
+
+class PageParser(HTMLParser):
+    """Collect the anchor ids a page defines and the links it makes."""
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.ids = set()
+        self.hrefs = []
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if attrs.get("id"):
+            self.ids.add(attrs["id"])
+        if tag == "a":
+            # Pre-HTML5 named anchors are still valid fragment targets.
+            if attrs.get("name"):
+                self.ids.add(attrs["name"])
+            if attrs.get("href") is not None:
+                self.hrefs.append(attrs["href"])
+
+
+class Page:
+    def __init__(self, ids, hrefs, redirect_to):
+        self.ids = ids
+        self.hrefs = hrefs
+        self.redirect_to = redirect_to
+
+
+def load_pages(root):
+    """Map each ``/path/to/page.html`` in the output to its parsed contents."""
+    pages = {}
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for name in filenames:
+            if not name.endswith(".html"):
+                continue
+            path = os.path.join(dirpath, name)
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                source = handle.read()
+            parser = PageParser()
+            parser.feed(source)
+            match = REFRESH_RE.search(source)
+            redirect_to = match.group(1) if match else None
+            key = "/" + os.path.relpath(path, root).replace(os.sep, "/")
+            pages[key] = Page(parser.ids, parser.hrefs, redirect_to)
+    return pages
+
+
+def page_key(pages, path):
+    """Resolve a URL path to the HTML file that serves it, if any."""
+    if path.endswith("/"):
+        candidate = path + "index.html"
+    elif path.endswith(".html"):
+        candidate = path
+    else:
+        candidate = path + "/index.html"
+    return candidate if candidate in pages else None
+
+
+def follow_redirects(pages, key):
+    """Chase meta-refresh alias stubs to the page that actually has content."""
+    seen = set()
+    for _ in range(MAX_REDIRECTS):
+        page = pages[key]
+        if not page.redirect_to or key in seen:
+            return key
+        seen.add(key)
+        target = urllib.parse.urlparse(urllib.parse.urljoin("https://freenet.org" + key, page.redirect_to))
+        if target.netloc not in INTERNAL_HOSTS:
+            return None
+        next_key = page_key(pages, target.path)
+        if next_key is None:
+            return None
+        key = next_key
+    return key
+
+
+def check(root):
+    """Return a list of ``(page, href, reason)`` for every broken link found."""
+    pages = load_pages(root)
+    broken = []
+    for source_key, page in sorted(pages.items()):
+        for href in page.hrefs:
+            url = urllib.parse.urlparse(
+                urllib.parse.urljoin("https://freenet.org" + source_key, href)
+            )
+            if url.scheme not in ("http", "https") or url.netloc not in INTERNAL_HOSTS:
+                continue  # mailto:, external site, protocol-relative CDN, ...
+            fragment = urllib.parse.unquote(url.fragment)
+            target_key = page_key(pages, url.path)
+            if target_key is None:
+                # Not a page; it may still be a static file such as a PDF.
+                on_disk = os.path.join(root, urllib.parse.unquote(url.path).lstrip("/"))
+                if not os.path.exists(on_disk):
+                    broken.append((source_key, href, "target does not exist"))
+                continue
+            if not fragment:
+                continue
+            resolved = follow_redirects(pages, target_key)
+            if resolved is None:
+                broken.append((source_key, href, "redirect target does not exist"))
+            elif fragment not in pages[resolved].ids:
+                broken.append((source_key, href, "no #%s on the target page" % fragment))
+    return len(pages), broken
+
+
+def report(root):
+    total, broken = check(root)
+    for source_key, href, reason in broken:
+        print("%s -> %s: %s" % (source_key, href, reason), file=sys.stderr)
+    if broken:
+        print(
+            "\n%d broken internal link(s) across %d page(s)." % (len(broken), total),
+            file=sys.stderr,
+        )
+        return 1
+    print("No broken internal links (%d pages checked)." % total)
+    return 0
+
+
+def self_test():
+    """Prove the checker actually fails on the bugs it claims to catch.
+
+    A link checker that silently stops checking is worse than none at all, so
+    CI runs this before trusting a clean report on the real site.
+    """
+    import shutil
+    import tempfile
+
+    root = tempfile.mkdtemp(prefix="check-links-selftest-")
+    try:
+        def write(path, body):
+            full = os.path.join(root, path)
+            os.makedirs(os.path.dirname(full), exist_ok=True)
+            with open(full, "w", encoding="utf-8") as handle:
+                handle.write(body)
+
+        write(
+            "faq/index.html",
+            """
+            <h1 id="what-is-freenet">What is Freenet?</h1>
+            <a href="#what-is-freenet">good fragment</a>
+            <a href="#deleted-section">BAD fragment</a>
+            <a name="legacy-anchor"></a>
+            <a href="#legacy-anchor">good named anchor</a>
+            <a href="/about/">good page</a>
+            <a href="/nope/">BAD page</a>
+            <a href="/paper.pdf">good static file</a>
+            <a href="/missing.pdf">BAD static file</a>
+            <a href="https://example.com/#whatever">external, not checked</a>
+            <a href="mailto:x@example.com">mailto, not checked</a>
+            <a href="/old-faq/#what-is-freenet">good through alias</a>
+            <a href="/old-faq/#gone">BAD through alias</a>
+            """,
+        )
+        write("about/index.html", "<p>hi</p>")
+        write(
+            "old-faq/index.html",
+            '<meta http-equiv="refresh" content="0; url=/faq/">',
+        )
+        write("paper.pdf", "%PDF-1.4")
+
+        _total, broken = check(root)
+        found = sorted(href for _src, href, _reason in broken)
+        expected = sorted(
+            ["#deleted-section", "/nope/", "/missing.pdf", "/old-faq/#gone"]
+        )
+        if found != expected:
+            print("self-test FAILED", file=sys.stderr)
+            print("  expected: %s" % expected, file=sys.stderr)
+            print("  found:    %s" % found, file=sys.stderr)
+            return 1
+        print("self-test passed (%d expected failures detected)" % len(expected))
+        return 0
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def main(argv):
+    if "--self-test" in argv:
+        return self_test()
+    root = argv[1] if len(argv) > 1 else "hugo-site/public"
+    if not os.path.isdir(root):
+        print("No such directory: %s (build the site first)" % root, file=sys.stderr)
+        return 2
+    return report(root)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check-links.py
+++ b/scripts/check-links.py
@@ -116,7 +116,10 @@ class PageParser(HTMLParser):
             if not value:
                 continue
             if attr == "srcset":
-                # "a.png 1x, b.png 2x" -> each candidate URL
+                # "a.png 1x, b.png 2x" -> each candidate URL. A data: URI
+                # contains commas of its own, so leave the whole value alone.
+                if value.strip().lower().startswith("data:"):
+                    continue
                 for candidate in value.split(","):
                     candidate = candidate.strip().split()
                     if candidate:
@@ -166,6 +169,20 @@ def site_hosts(root):
     return hosts
 
 
+def resolves_to_file(root, path):
+    """True if a URL path names a real file inside the output tree.
+
+    A directory is not a valid target (the server 404s on it), and a path that
+    escapes ``root`` via ".." is never satisfied by something outside the
+    build.
+    """
+    candidate = os.path.realpath(os.path.join(root, path.lstrip("/")))
+    root = os.path.realpath(root)
+    if candidate != root and not candidate.startswith(root + os.sep):
+        return False
+    return os.path.isfile(candidate)
+
+
 def page_key(pages, path):
     """Resolve a URL path to the HTML file that serves it, if any."""
     if path.endswith("/"):
@@ -177,29 +194,33 @@ def page_key(pages, path):
     return candidate if candidate in pages else None
 
 
-def follow_redirects(pages, key):
+def follow_redirects(pages, hosts, key):
     """Chase meta-refresh alias stubs to the page that actually has content.
 
-    Returns ``(key, None)`` on success or ``(None, reason)`` if the chain does
-    not land anywhere real.
+    Returns ``(key, None)`` on success, ``(None, None)`` if the chain leaves
+    the site (not ours to verify), or ``(None, reason)`` if it does not land
+    anywhere real.
     """
+    base_host = "https://" + sorted(hosts)[0]
     seen = set()
-    while True:
+    # Bounded by iteration, not by len(seen): a two-page cycle revisits the
+    # same keys forever without growing the set, so counting hops is what
+    # guarantees termination and `seen` only names the reason.
+    for _ in range(MAX_REDIRECTS + 1):
         page = pages[key]
         if not page.redirect_to:
             return key, None
         if key in seen:
             return None, "redirect loop"
-        if len(seen) >= MAX_REDIRECTS:
-            return None, "redirect chain longer than %d hops" % MAX_REDIRECTS
         seen.add(key)
-        target = urllib.parse.urlparse(
-            urllib.parse.urljoin("https://site.invalid" + key, page.redirect_to)
-        )
-        next_key = page_key(pages, target.path)
+        target = urllib.parse.urlparse(urllib.parse.urljoin(base_host + key, page.redirect_to))
+        if (target.hostname or "").lower() not in hosts:
+            return None, None  # redirected off-site; the fragment is not ours
+        next_key = page_key(pages, urllib.parse.unquote(target.path))
         if next_key is None:
             return None, "redirect target does not exist"
         key = next_key
+    return None, "redirect chain longer than %d hops" % MAX_REDIRECTS
 
 
 def check(root):
@@ -207,36 +228,40 @@ def check(root):
     ``(page, reference, reason)``."""
     pages = load_pages(root)
     hosts = site_hosts(root)
+    # Any of our own hosts works as the base: urljoin resolves the path the
+    # same way whichever it is, and it only has to be one we call internal.
+    base_host = "https://" + sorted(hosts)[0]
     broken = []
     for source_key, page in sorted(pages.items()):
         for reference in page.references:
-            url = urllib.parse.urlparse(
-                urllib.parse.urljoin("https://" + sorted(hosts)[0] + source_key, reference)
-            )
+            url = urllib.parse.urlparse(urllib.parse.urljoin(base_host + source_key, reference))
             if url.scheme not in ("http", "https"):
                 continue  # mailto:, data:, javascript:, ...
             if (url.hostname or "").lower() not in hosts:
                 continue  # another site; not ours to verify
             fragment = urllib.parse.unquote(url.fragment)
+            # Hugo writes paths as raw UTF-8 but emits hrefs percent-encoded,
+            # so everything downstream works on the decoded path.
             path = urllib.parse.unquote(url.path)
 
-            target_key = page_key(pages, url.path)
+            target_key = page_key(pages, path)
             if target_key is None:
                 # Not a page, so it has to be a file that exists — a directory
                 # with no index.html is a 404, not a valid target.
-                if not os.path.isfile(os.path.join(root, path.lstrip("/"))):
+                if not resolves_to_file(root, path):
                     broken.append((source_key, reference, "target does not exist"))
                 continue
 
-            if not fragment or fragment in ALWAYS_VALID_FRAGMENTS:
+            if not fragment or fragment.lower() in ALWAYS_VALID_FRAGMENTS:
                 continue
             # Check the page's own ids before following any redirect: a real
             # page can carry a meta refresh and still be the fragment's home.
             if fragment in pages[target_key].ids:
                 continue
-            resolved, reason = follow_redirects(pages, target_key)
+            resolved, reason = follow_redirects(pages, hosts, target_key)
             if resolved is None:
-                broken.append((source_key, reference, reason))
+                if reason is not None:
+                    broken.append((source_key, reference, reason))
             elif fragment not in pages[resolved].ids:
                 broken.append((source_key, reference, "no #%s on the target page" % fragment))
     return len(pages), broken
@@ -266,6 +291,8 @@ def self_test():
     CI runs this before trusting a clean report on the real site. Every case
     below is one a previous version of this script got wrong.
     """
+    import contextlib
+    import io
     import shutil
     import tempfile
 
@@ -302,17 +329,54 @@ def self_test():
             <a href="/old-faq/#what-is-freenet">good through alias</a>
             <a href="/old-faq/#gone">BAD through alias</a>
             <a href="/loop-a/#anything">BAD: redirect loop</a>
+            <a href="/chain-1/#anything">BAD: chain longer than the hop cap</a>
+            <a href="/dangling-alias/#anything">BAD: alias to a page that is not there</a>
+            <a href="/offsite-alias/#anything">good: alias leaves the site, not ours to check</a>
             <a href="/documented/#really-here">good: refresh in body is not an alias</a>
             <a href="/body-refresh/#what-is-freenet">BAD: body refresh is not an alias to follow</a>
+            <a href="/head-refresh-with-id/#own">good: page owns the id, so do not follow</a>
             <a href="/dup-attr/" href="/about/">BAD: a browser honours the first href</a>
             <a href="HTTPS://FREENET.ORG/nope/">BAD: uppercase host is still us</a>
             <a href="https://freenet.org:443/nope/">BAD: default port is still us</a>
+            <a href="#TOP">good: #top is case-insensitive</a>
+            <a href="/caf%C3%A9/">good: percent-encoded path, raw UTF-8 on disk</a>
+            <a href="/caf%C3%A9/#accented">good: fragment through a percent-encoded path</a>
+            <a href="/%2e%2e/%2e%2e/etc/hostname">BAD: must not escape the output tree</a>
+            <img srcset="data:image/png;base64,iVBORw0KGgo= 1x">
+            <a href="https://sitemap-host.example/nope/">BAD: host taken from sitemap.xml</a>
             """,
+        )
+        # The build's own hostname comes from here, not just the hardcoded set.
+        write(
+            "sitemap.xml",
+            '<?xml version="1.0"?><urlset><url><loc>https://sitemap-host.example/about/</loc>'
+            "</url></urlset>",
         )
         write("about/index.html", "<p>hi</p>")
         write("old-faq/index.html", '<head><meta http-equiv="refresh" content="0; url=/faq/"></head>')
         write("loop-a/index.html", '<head><meta http-equiv="refresh" content="0; url=/loop-b/"></head>')
         write("loop-b/index.html", '<head><meta http-equiv="refresh" content="0; url=/loop-a/"></head>')
+        for hop in range(1, MAX_REDIRECTS + 2):
+            write(
+                "chain-%d/index.html" % hop,
+                '<head><meta http-equiv="refresh" content="0; url=/chain-%d/"></head>' % (hop + 1),
+            )
+        write(
+            "dangling-alias/index.html",
+            '<head><meta http-equiv="refresh" content="0; url=/never-built/"></head>',
+        )
+        write(
+            "offsite-alias/index.html",
+            '<head><meta http-equiv="refresh" content="0; url=https://example.com/faq/"></head>',
+        )
+        # A page can carry a head refresh and still be the fragment's own home;
+        # its ids must be consulted before the redirect is followed.
+        write(
+            "head-refresh-with-id/index.html",
+            '<head><meta http-equiv="refresh" content="30; url=/about/"></head>'
+            '<body><h2 id="own">still the right page</h2></body>',
+        )
+        write("café/index.html", '<h2 id="accented">café</h2>')
         # A real page that merely *documents* a meta refresh must not be
         # mistaken for an alias stub.
         write(
@@ -345,10 +409,14 @@ def self_test():
                 "/missing.js",
                 "/old-faq/#gone",
                 "/loop-a/#anything",
+                "/chain-1/#anything",
+                "/dangling-alias/#anything",
                 "/body-refresh/#what-is-freenet",
                 "/dup-attr/",
                 "HTTPS://FREENET.ORG/nope/",
                 "https://freenet.org:443/nope/",
+                "/%2e%2e/%2e%2e/etc/hostname",
+                "https://sitemap-host.example/nope/",
             ]
         )
         if found != expected:
@@ -356,6 +424,21 @@ def self_test():
             print("  missing: %s" % sorted(set(expected) - set(found)), file=sys.stderr)
             print("  unexpected: %s" % sorted(set(found) - set(expected)), file=sys.stderr)
             return 1
+
+        # report() owns the "nothing was built" guard, so exercise it here too:
+        # check() alone cannot tell an empty tree from a clean one.
+        empty = tempfile.mkdtemp(prefix="check-links-selftest-empty-")
+        try:
+            with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+                io.StringIO()
+            ):
+                empty_status = report(empty)
+            if empty_status != 2:
+                print("self-test FAILED: empty output tree did not exit 2", file=sys.stderr)
+                return 1
+        finally:
+            shutil.rmtree(empty, ignore_errors=True)
+
         print("self-test passed (%d expected failures detected)" % len(expected))
         return 0
     finally:


### PR DESCRIPTION
## Problem

A user reported that <https://freenet.org/about/faq/#what-is-the-status-of-freenet> goes nowhere.
It has been dead since March 2025, when 6b9cf202 deleted the "What is the status of Freenet?"
section but left its entry in the FAQ's hand-maintained table of contents.

It was not the only one. Auditing every internal link in the built site turned up **33 broken
links**. Counts are occurrences, so `/build/` is 12 across 11 distinct hrefs (`introduction`
appears twice):

| Page | Broken | Cause |
|---|---|---|
| `/about/faq/` | 2 | `#what-is-the-status-of-freenet` (section deleted Mar 2025); `#what-is-freenet` (heading deleted Jun 2024 by 947e2081, in the same edit that introduced the hand-written TOC) |
| `/about/` | 16 | the section template renders each child's `.Summary`; the FAQ's summary *was* that TOC list, so every entry landed on `/about/` as a dead fragment |
| `/about/news/456-mitigating-sybil-attacks-in-freenet/` | 3 | links to `#identity-creation-cost` / `#location-hopping`, but the headings are numbered (`#1-…`, `#2-…`); `#peer-pressure` names a section that was never written |
| `/build/` | 12 | the manual index's summary leaks page-relative hrefs (`introduction`, `components/overview`, `#developer-guide`) that resolve against `/build/` instead of `/build/manual/` |

Two root causes:

**1. The FAQ's TOC was maintained by hand.** The `{{< toc >}}` shortcode meant to generate it has
been broken since its first commit — it runs `findRE "(?m)^# (.+)$"` over already-`plainify`d HTML,
which never matches, so it emitted an empty `<ul>` on every render. With no working generator, the
list drifted from the headings.

**2. Section-index cards render a child's auto-summary verbatim**, carrying that child's
page-relative hrefs, which then resolve against the *parent's* URL. That accounts for 28 of the 33.

## Approach

- **`{{< toc >}}` now emits `.Page.Fragments.ToHTML 1 3`**, generated from the headings actually
  present. A TOC entry can no longer outlive its section. Levels are scoped to the shortcode, so no
  site-global markup config is needed; the rendered FAQ page is byte-identical to the hand-written
  version minus the dead entry, on both Hugo 0.146.4 and 0.154.5.
- **Restored `# What is Freenet? {#what-is-freenet}`**, lost in June 2024.
- **Explicit `summary:`** on the FAQ, the manual index and the history page — the three whose
  auto-summary was leaking links or dumping their own headings onto a card.
- **Sybil post**: links repointed at the real heading ids. Items 3 and 4 unlinked — item 3 names a
  section that was never written (`git log -p --follow` has zero hits for "Peer Pressure"), and
  item 4 pointed at `pivotaltracker.com`, which no longer resolves.

The templates themselves are unchanged, deliberately — see below.

## Testing

Hugo does not validate fragments and neither did CI, which is why a dead link survived a year on
one of the site's most-read pages. `scripts/check-links.py` resolves every same-site reference in
the built output — `<a href>` plus `img`/`link`/`script`/`iframe`/`source`/`video`/`audio`/`area`/
`embed`/`object`/`track` — against the pages and files that exist, follows Hugo's alias redirect
stubs, and checks each `#fragment` against the ids on its target page. External URLs are skipped so
the check stays offline and deterministic.

```
# against the pre-fix build
33 broken internal link(s) across 222 page(s).   exit 1

# against this build
No broken internal links (222 pages checked).    exit 0
```

It gates both publish paths — `deploy.yml` (GitHub Pages, and it runs on PRs) and
`publish-freenet.yml` (the Freenet contract), which previously could ship content GitHub Pages had
rejected, silently diverging the two mirrors. `cargo-make` aborts on the first failing command,
verified by injecting a broken link into the built output.

The script carries a `--self-test` that builds a synthetic site with 17 known-bad references and
asserts it flags exactly those. That is not decoration: of 21 sabotages of `check()`, 19 are caught
by `--self-test` alone, and the two survivors change only the reason string while still reporting
the link as broken. CI runs it before trusting a clean report, so a checker that quietly stops
checking fails rather than reporting success.

Verified in a browser at 1280px and 390px, light and dark, and against both Hugo 0.146.4 (CI's pin)
and 0.154.5.

## Review

Four independent blind reviewers on the first commit (code-first, adversarial, CI/deploy,
big-picture), then three more on the changes those produced. The second round was worth it — it
caught two things I had got wrong:

- **A blocking regression I introduced.** Tightening the static-file check from `os.path.exists` to
  `os.path.isfile` (correct on its own — a directory with no `index.html` is a 404) turned a silent
  pass into a false positive for any page whose path contains a non-ASCII character, because the
  page lookup was still using the percent-encoded path. One accented contributor name in
  `/about/people/` would have blocked the deploy.
- **A template change that did more harm than good.** I had rewritten `.Summary` in
  `list.html`/`single.html` to strip links, to retire the mechanism behind 28 of the 33 broken
  links. Classifying every anchor it actually removed showed 26 absolute and 9 root-relative
  hrefs — and zero page-relative or fragment ones, because the `summary:` front matter had already
  fixed those. Its whole measurable effect was deleting 34 *working* links across 6 pages
  (`/about/news/` cards ending in "Also available on" above an unclickable list;
  `/build/manual/components/` losing "see Client SDKs", which has no sibling card, so the sentence
  pointed at nothing). Reverted. The mechanism is instead handled by convention plus the CI gate,
  with a note in the template. Scoping such a transform to relative hrefs only would fix the
  mechanism without the collateral damage — a reasonable follow-up, not something to land untested
  here.

Two findings deliberately not acted on:

- **Explicit `{#identity-creation-cost}` ids on the Sybil headings.** Those headings have carried
  numbers since the post was written, so the un-numbered fragments were never live ids and nothing
  links to them; adding explicit ids would change the ids that *are* live.
- **Making `build` a required status check on `main`.** This repo has no rulesets and no branch
  protection, so the check is advisory: once a broken link reaches `main`, the deploy freezes on
  every subsequent push until someone notices. Making it required would turn that into "the PR
  can't merge", which is the better failure mode — but that is a repo-governance change beyond a
  link-repair PR.

## Two pre-existing bugs found along the way

- **`/community/get-involved/` was nondeterministic.** `community/get-involved.md` and
  `community/get-involved/index.md` both claimed that URL, and Hugo picked a winner per build — 4
  of 20 identical builds served a different page, so freenet.org has been flipping between two
  versions on every deploy. `hugo --printPathWarnings` reports it; the plain build CI runs does
  not. Fixed here (12/12 builds identical after), because it also meant the gated build could
  differ from the published one.
- **The Freenet-published mirror ships ~292 broken references**, 264 of them a `<script src>` 404
  on every page, because `build-freenet` deletes files that the templates still reference. Filed as
  #104 rather than widened into this PR.

Also worth a maintainer's judgement, outside this PR: the FAQ no longer answers "what is the status
of Freenet?" at all, and the nav has no Status or Roadmap entry. Anyone arriving on the reported URL
is by definition asking that question. Restoring a dated answer would repeat the 2025 mistake, but
an evergreen entry pointing at `/about/news/` would serve them.

[AI-assisted - Claude]