### PR TITLE
test(check-links): pin the three percent-decode calls in the self-test

### DIFF
--- a/scripts/check-links.py
+++ b/scripts/check-links.py
@@ -341,6 +341,8 @@ def self_test():
             <a href="#TOP">good: #top is case-insensitive</a>
             <a href="/caf%C3%A9/">good: percent-encoded path, raw UTF-8 on disk</a>
             <a href="/caf%C3%A9/#accented">good: fragment through a percent-encoded path</a>
+            <a href="/caf%C3%A9/#r%C3%A9sum%C3%A9">good: percent-encoded fragment too</a>
+            <a href="/encoded-alias/#accented">good: alias whose refresh URL is encoded</a>
             <a href="/%2e%2e/%2e%2e/etc/hostname">BAD: must not escape the output tree</a>
             <img srcset="data:image/png;base64,iVBORw0KGgo= 1x">
             <a href="https://sitemap-host.example/nope/">BAD: host taken from sitemap.xml</a>
@@ -376,7 +378,14 @@ def self_test():
             '<head><meta http-equiv="refresh" content="30; url=/about/"></head>'
             '<body><h2 id="own">still the right page</h2></body>',
         )
-        write("café/index.html", '<h2 id="accented">café</h2>')
+        # Both decode calls need a fixture that only passes when they run: an
+        # id that is non-ASCII (not just the path holding it), and an alias
+        # whose refresh URL is itself percent-encoded.
+        write("café/index.html", '<h2 id="accented">café</h2><h3 id="résumé">r</h3>')
+        write(
+            "encoded-alias/index.html",
+            '<head><meta http-equiv="refresh" content="0; url=/caf%C3%A9/"></head>',
+        )
         # A real page that merely *documents* a meta refresh must not be
         # mistaken for an alias stub.
         write(


### PR DESCRIPTION
Follow-up to #103, test-only.

That PR's self-test grew a `/café/` page to cover percent-encoded paths, but the fixture used an
ASCII fragment (`#accented`) and an ASCII alias target, so only one of `check-links.py`'s three
`unquote()` calls was actually exercised. Deleting the decode on the *fragment*, or the one in the
*redirect path*, still passed the self-test.

That is worth closing because a mis-decoded path is exactly the bug this file shipped once already
during #103's review: tightening the static-file branch from `os.path.exists` to `os.path.isfile`
(correct on its own) turned a silently-passing encoded lookup into a CI failure for any page whose
URL contains a non-ASCII character. The code is right now; the test just wasn't holding it there.

Two lines in the existing fixture:

- a non-ASCII id (`#résumé`) reached through a percent-encoded fragment
- an alias whose `refresh` URL is itself percent-encoded

## Testing

Mutation-tested, deleting each `unquote()` in turn:

| mutant | before | after |
|---|---|---|
| decode dropped on the path | caught | caught |
| decode dropped on the fragment | **survived** | caught |
| decode dropped on the redirect path | **survived** | caught |

`--self-test` still passes (17 expected failures), and the real site is still clean — no broken
internal links across 222 pages.

Credit to the review pass on #103 for spotting that the fixture didn't discriminate.

[AI-assisted - Claude]