### PR TITLE
fix(ghostkey): link the vault, and stop warning it loses keys

### DIFF
--- a/hugo-site/content/ghostkey/_index.md
+++ b/hugo-site/content/ghostkey/_index.md
@@ -203,6 +203,18 @@ the vault holds the only copy, some nodes reclaim idle storage, and a key you ca
 produce is a donation you cannot prove. A backup also lets you move your identity to a
 new node later.
 
+### Opening your vault
+
+If you have a Freenet node running on this computer, your Ghost Keys are here:
+
+<div class="gk-cta">
+<a href="http://localhost:7509/v1/contract/web/DLog47hEsrtuGT4N5XCeMBG45m4n1aWM89tBZXue2E1N/" class="funding-donate-button">Open your Ghost Key vault</a>
+<p class="gk-cta-note">Requires a Freenet node running on this computer. The link will not resolve otherwise.</p>
+</div>
+
+That address is your own machine, not a website — the vault runs inside your node, and the page is
+served locally. Bookmark it if you use Ghost Keys regularly.
+
 For developers, everything is open source:
 
 - The [`freenet/ghostkeys`](https://github.com/freenet/ghostkeys) repository contains

--- a/hugo-site/content/ghostkey/create/_index.md
+++ b/hugo-site/content/ghostkey/create/_index.md
@@ -15,11 +15,10 @@ Ghost Key is a persistent pseudonym, and two messages signed with the same one c
 same holder. We set out the limits in
 [what Ghost Keys don't hide](/ghostkey/#what-ghost-keys-dont-hide).
 
-> **Before you pay:** after donating you'll download your certificate and signing key, and that
-> download is the authoritative copy. Keep it somewhere safe, such as a secure note in a password
-> manager. The Ghostkey Vault you can import it into is still experimental and can currently lose
-> keys ([freenet/ghostkeys#3](https://github.com/freenet/ghostkeys/issues/3)), so the backup is what
-> protects you.
+> **Before you pay:** your Ghost Key is created in your browser on the next page and signed once.
+> That page is the only copy — reloading it will not bring the key back and the donation cannot be
+> reissued — so download it or import it to Freenet before closing the tab. Keep the downloaded file
+> somewhere safe, such as a secure note in a password manager.
 
 The minimum is **$1**. We use [Stripe](https://stripe.com/) for card processing. Freenet Project Inc
 is a 501(c)(3) nonprofit, and contributions are tax-deductible in the United States.

--- a/hugo-site/content/ghostkey/success/_index.md
+++ b/hugo-site/content/ghostkey/success/_index.md
@@ -28,4 +28,10 @@ You can also download the certificate and signing key from this page right now
 if you would rather not wait — either copy works, and the vault can re-import
 from one at any time.
 
+**Your vault lives at**
+[localhost:7509/v1/contract/web/DLog47hEs…](http://localhost:7509/v1/contract/web/DLog47hEsrtuGT4N5XCeMBG45m4n1aWM89tBZXue2E1N/),
+on this computer rather than on the web. Importing opens it for you, but the
+address is worth bookmarking — it is how you reach your keys later, and nothing
+else links to it.
+
 {{< bulma-button href="/ghostkey/" color="#339966" >}}Ghost Key FAQ{{< /bulma-button >}}


### PR DESCRIPTION
Two things, both spotted by @sanity noticing the vault isn't linked from anywhere.

## The vault was reachable from nowhere

Its contract id appeared in **exactly one place** on the entire site — the import button's JavaScript. Meanwhile the prose names "the Ghostkey Vault" six times without ever linking it.

So the only way in was to complete a purchase and click Import. Anyone who already held Ghost Keys had **no route at all**, and anyone who closed that tab afterwards had no way back.

Adds a link on `/ghostkey/` in the section already about storage and backup, and names the address on the success page. Both state plainly that it needs a Freenet node on the same computer and won't resolve otherwise — the address is the user's own machine, not a website, which isn't obvious from a link on a public site.

## The pre-purchase warning was wrong

`/ghostkey/create/` told people, in a blockquote immediately before paying:

> The Ghostkey Vault you can import it into is still experimental and can currently lose keys ([freenet/ghostkeys#3](https://github.com/freenet/ghostkeys/issues/3)), so the backup is what protects you.

**ghostkeys#3 is closed and fixed.** That's inaccurate friction at the exact moment someone is deciding whether to spend money — telling them the thing they're buying might vanish.

My earlier staleness sweep missed it because I checked `/ghostkey/_index.md` and never opened the create page's own copy. Owning that: the sweep was less thorough than I reported it as.

Replaced with what's actually true and more useful — the key is created in the browser on the next page and signed once, that page is the only copy, and the donation cannot be reissued, so download or import before closing the tab. Same fact #102 warns about *after* payment, now stated before the money is spent.

## Verification

Driven in a browser against a real build: link renders and points at the local node, the caveat is present, the stale claim is gone, the new warning explains the one-shot page, and the success page names the address. **6/6.**

One check initially failed and was my error, not the page's — it grabbed `.gk-cta-note` with `.last()`, which picked the existing donate CTA rather than the vault one.

[AI-assisted - Claude]