### PR TITLE
docs(faq): add FAQ on legality of running a Freenet peer

### DIFF
--- a/hugo-site/content/about/faq/index.md
+++ b/hugo-site/content/about/faq/index.md
@@ -239,27 +239,28 @@ method can work as well or better.
 
 # Is it legal to run a Freenet peer? {#is-it-legal-to-run-a-freenet-peer}
 
-Generally speaking, yes. Running a Freenet peer does not mean you endorse or intentionally publish
-every piece of information the peer may automatically route or cache. Internet law has long
-distinguished between people who intentionally publish material and network intermediaries that
-automatically transmit or cache third-party material.
+Generally speaking, yes. Running a Freenet peer is like running any other network infrastructure
+that automatically handles other people's traffic, a role internet law has long distinguished from
+intentionally publishing material. Running a peer does not mean you endorse or intentionally publish
+every piece of information it may automatically route or cache.
 
-As a concrete U.S. example, [17 U.S.C. §512](https://www.law.cornell.edu/uscode/text/17/512) (part
-of the DMCA) expressly addresses both "transitory digital network communications," including
-automatic transmission, routing, and intermediate or transient storage, and "system caching,"
-covering certain automatic temporary storage of third-party material. The
-[U.S. Copyright Office](https://www.copyright.gov/512/) similarly describes §512 as covering service
+A concrete U.S. example is [17 U.S.C. §512](https://www.law.cornell.edu/uscode/text/17/512), part of
+the DMCA. It expressly addresses "transitory digital network communications" (automatic
+transmission, routing, and intermediate or transient storage) and "system caching" (certain
+automatic temporary storage of third-party material). The
+[U.S. Copyright Office](https://www.copyright.gov/512/) likewise describes §512 as covering service
 providers acting as conduits and providers that cache material automatically. This is useful
 evidence that operating infrastructure which automatically handles third-party information is a
-legally recognized role, distinct from intentionally publishing that information.
+legally recognized role, separate from publishing that information.
 
-That said, §512 is specific to copyright, and its protections come with conditions attached, so
-it's best read as a useful precedent rather than a blanket guarantee against legal risk. For someone
-running a peer normally, the distinction that matters is automatic versus knowing: routing or
-caching traffic automatically is not the same as knowingly facilitating unlawful activity. It's a
-different story for anyone hoping to hide behind the network while doing the latter: the Freenet
-Platform itself wasn't designed to provide anonymity (see
-[above](#does-freenet-provide-anonymity-like-tor-or-i2p)), so it should not be relied on for cover.
+That said, §512 covers only copyright, and its protections come with conditions, so it is best read
+as a useful precedent rather than a blanket guarantee against legal risk. For someone running a peer
+normally, the distinction that matters is automatic versus knowing: automatically routing or caching
+traffic is not the same as knowingly facilitating unlawful activity. It's a different story for
+anyone hoping to use the network to hide unlawful activity: the Freenet Platform wasn't designed to
+provide anonymity (see
+[Does Freenet provide anonymity like Tor or I2P?](#does-freenet-provide-anonymity-like-tor-or-i2p))
+and should not be relied on for that kind of cover.
 
 # Can I follow Freenet on social media? {#can-i-follow-freenet-on-social-media}
 

--- a/hugo-site/content/about/faq/index.md
+++ b/hugo-site/content/about/faq/index.md
@@ -237,6 +237,27 @@ the foundation for a decentralized reputation system that respects privacy.
 No filtering approach is perfect, especially in centralized systems, but we think a decentralized
 method can work as well or better.
 
+# Is it legal to run a Freenet peer? {#is-it-legal-to-run-a-freenet-peer}
+
+Running a Freenet peer does not mean you endorse or intentionally publish every piece of information
+the peer may automatically route or cache. Internet law has long distinguished between people who
+intentionally publish material and network intermediaries that automatically transmit or cache
+third-party material.
+
+As a concrete U.S. example, [17 U.S.C. §512](https://www.law.cornell.edu/uscode/text/17/512) (part
+of the DMCA) expressly addresses both "transitory digital network communications," including
+automatic transmission, routing, and intermediate or transient storage, and "system caching,"
+covering certain automatic temporary storage of third-party material. The
+[U.S. Copyright Office](https://www.copyright.gov/512/) similarly describes §512 as covering service
+providers acting as conduits and providers that cache material automatically. This is useful
+evidence that operating infrastructure which automatically handles third-party information is a
+legally recognized role, distinct from intentionally publishing that information.
+
+That said, §512 concerns copyright liability specifically and its safe harbors have statutory
+requirements, so it shouldn't be read as a blanket guarantee that running a Freenet peer can never
+create legal liability. Other laws and jurisdictions may apply, particularly where an operator
+knowingly participates in unlawful activity.
+
 # Can I follow Freenet on social media? {#can-i-follow-freenet-on-social-media}
 
 Yes, you can follow [\@FreenetOrg](https://twitter.com/freenetorg) on Twitter/X or discuss

--- a/hugo-site/content/about/faq/index.md
+++ b/hugo-site/content/about/faq/index.md
@@ -239,10 +239,10 @@ method can work as well or better.
 
 # Is it legal to run a Freenet peer? {#is-it-legal-to-run-a-freenet-peer}
 
-Running a Freenet peer does not mean you endorse or intentionally publish every piece of information
-the peer may automatically route or cache. Internet law has long distinguished between people who
-intentionally publish material and network intermediaries that automatically transmit or cache
-third-party material.
+Generally speaking, yes. Running a Freenet peer does not mean you endorse or intentionally publish
+every piece of information the peer may automatically route or cache. Internet law has long
+distinguished between people who intentionally publish material and network intermediaries that
+automatically transmit or cache third-party material.
 
 As a concrete U.S. example, [17 U.S.C. §512](https://www.law.cornell.edu/uscode/text/17/512) (part
 of the DMCA) expressly addresses both "transitory digital network communications," including
@@ -253,10 +253,13 @@ providers acting as conduits and providers that cache material automatically. Th
 evidence that operating infrastructure which automatically handles third-party information is a
 legally recognized role, distinct from intentionally publishing that information.
 
-That said, §512 concerns copyright liability specifically and its safe harbors have statutory
-requirements, so it shouldn't be read as a blanket guarantee that running a Freenet peer can never
-create legal liability. Other laws and jurisdictions may apply, particularly where an operator
-knowingly participates in unlawful activity.
+That said, §512 is specific to copyright, and its protections come with conditions attached, so
+it's best read as a useful precedent rather than a blanket guarantee against legal risk. For someone
+running a peer normally, the distinction that matters is automatic versus knowing: routing or
+caching traffic automatically is not the same as knowingly facilitating unlawful activity. It's a
+different story for anyone hoping to hide behind the network while doing the latter — the Freenet
+Platform itself wasn't designed to provide anonymity (see
+[above](#does-freenet-provide-anonymity-like-tor-or-i2p)), so it should not be relied on for cover.
 
 # Can I follow Freenet on social media? {#can-i-follow-freenet-on-social-media}
 

--- a/hugo-site/content/about/faq/index.md
+++ b/hugo-site/content/about/faq/index.md
@@ -257,7 +257,7 @@ That said, §512 is specific to copyright, and its protections come with conditi
 it's best read as a useful precedent rather than a blanket guarantee against legal risk. For someone
 running a peer normally, the distinction that matters is automatic versus knowing: routing or
 caching traffic automatically is not the same as knowingly facilitating unlawful activity. It's a
-different story for anyone hoping to hide behind the network while doing the latter — the Freenet
+different story for anyone hoping to hide behind the network while doing the latter: the Freenet
 Platform itself wasn't designed to provide anonymity (see
 [above](#does-freenet-provide-anonymity-like-tor-or-i2p)), so it should not be relied on for cover.
 

--- a/hugo-site/content/about/faq/index.md
+++ b/hugo-site/content/about/faq/index.md
@@ -34,8 +34,8 @@ scalability. Keys in this key-value store are
 - How can the value be efficiently synchronized between peers in the network
 
 These webassembly keys are also known as
-[contracts](https://freenet.org/build/manual/components/contracts/), and the values are also known as
-the contract's **state**.
+[contracts](https://freenet.org/build/manual/components/contracts/), and the values are also known
+as the contract's **state**.
 
 Like the web, most people will interact with Freenet through their web browser. Freenet provides a
 local [HTTP proxy](https://freenet.org/build/manual/components/ui/) that allows data such as a
@@ -201,8 +201,8 @@ network.
   personal rather than global, there's no central registry to control and no race to squat every
   good name.
 
-- **Discovery:** "Find the thing I want" is really a search problem, not a naming one, and search and
-  recommendation handle it better than a global namespace can. That's what we're designing in
+- **Discovery:** "Find the thing I want" is really a search problem, not a naming one, and search
+  and recommendation handle it better than a global namespace can. That's what we're designing in
   [Atlas](https://github.com/freenet/atlas), a decentralized discovery layer that's still at the
   design stage.
 
@@ -290,17 +290,27 @@ Run:
 freenet uninstall
 ```
 
-This stops the service, removes the `freenet` and `fdev` binaries, and (with confirmation) deletes your data, config, cache, and logs. Pass `--purge` to skip the confirmation, or `--keep-data` to preserve all of them.
+This stops the service, removes the `freenet` and `fdev` binaries, and (with confirmation) deletes
+your data, config, cache, and logs. Pass `--purge` to skip the confirmation, or `--keep-data` to
+preserve all of them.
 
-**Do not run `sudo freenet uninstall`** if you installed with the `curl | sh` one-liner. The installer puts the binary in `~/.local/bin`, which is not on `sudo`'s default PATH, so the command fails with `command not found` and your install is left untouched. Only use `sudo` if you originally installed with `--system`.
+**Do not run `sudo freenet uninstall`** if you installed with the `curl | sh` one-liner. The
+installer puts the binary in `~/.local/bin`, which is not on `sudo`'s default PATH, so the command
+fails with `command not found` and your install is left untouched. Only use `sudo` if you originally
+installed with `--system`.
 
-If the `freenet` binary isn't on your PATH, invoke it by full path: `~/.local/bin/freenet uninstall`.
+If the `freenet` binary isn't on your PATH, invoke it by full path:
+`~/.local/bin/freenet uninstall`.
 
-If you installed with `cargo install freenet`, the binary is in `~/.cargo/bin/freenet`; run `cargo uninstall freenet` and then clean up the data directories below.
+If you installed with `cargo install freenet`, the binary is in `~/.cargo/bin/freenet`; run
+`cargo uninstall freenet` and then clean up the data directories below.
 
-On Windows, `freenet uninstall` has a known gap and may leave the config folder behind; after running it, also manually remove `%LOCALAPPDATA%\Freenet\bin`, `%LOCALAPPDATA%\The Freenet Project Inc\Freenet`, and `%APPDATA%\The Freenet Project Inc\Freenet`.
+On Windows, `freenet uninstall` has a known gap and may leave the config folder behind; after
+running it, also manually remove `%LOCALAPPDATA%\Freenet\bin`,
+`%LOCALAPPDATA%\The Freenet Project Inc\Freenet`, and `%APPDATA%\The Freenet Project Inc\Freenet`.
 
-The [Uninstall guide](/uninstall/) has the full per-platform manual-fallback snippets (Linux systemd, macOS launchd, Windows PowerShell) for when the binary is missing or broken.
+The [Uninstall guide](/uninstall/) has the full per-platform manual-fallback snippets (Linux
+systemd, macOS launchd, Windows PowerShell) for when the binary is missing or broken.
 
 # Why does the Freenet project use and mention AI tools? {#why-does-the-freenet-project-use-and-mention-ai-tools}
 


### PR DESCRIPTION
## Problem
People considering running a Freenet peer sometimes worry they could face legal trouble simply because the peer automatically routes or caches third-party contract state it doesn't control.

## Approach
Adds one new FAQ entry, placed immediately after "How does Freenet handle harmful content?", explaining that running infrastructure which automatically routes/caches third-party material is legally distinct from intentionally publishing it. Cites 17 U.S.C. §512 (DMCA conduit/caching safe harbors) and the U.S. Copyright Office's explanation of §512 as concrete evidence of this distinction, while being explicit that:
- §512 is copyright-specific and has statutory requirements, not a blanket guarantee
- other laws/jurisdictions may still apply, especially for knowing participation in unlawful activity

No claim is made that Freenet peers are automatically covered by the DMCA, and no claim is made that Freenet determines what content is legal.

## Testing
- `hugo --gc --minify` — site builds cleanly
- `python3 scripts/check-links.py --self-test` — passes
- `python3 scripts/check-links.py hugo-site/public` — no broken internal links (222 pages checked)

[AI-assisted - Claude]