### PR TITLE
docs(faq): drop the bare legality conclusion from the peer-legality opener

### DIFF
--- a/hugo-site/content/about/faq/index.md
+++ b/hugo-site/content/about/faq/index.md
@@ -248,11 +248,10 @@ One example comes from U.S. law, used here for illustration rather than as a uni
 [17 U.S.C. §512](https://www.law.cornell.edu/uscode/text/17/512), part of the DMCA. It expressly
 addresses "transitory digital network communications" (automatic transmission, routing, and
 intermediate or transient storage) and "system caching" (certain automatic temporary storage of
-third-party material). The
-[U.S. Copyright Office](https://www.copyright.gov/512/) likewise describes §512 as covering service
-providers acting as conduits and providers that cache material automatically. This is useful
-evidence that operating infrastructure which automatically handles third-party information is a
-legally recognized role, separate from publishing that information.
+third-party material). The [U.S. Copyright Office](https://www.copyright.gov/512/) likewise
+describes §512 as covering service providers acting as conduits and providers that cache material
+automatically. This is useful evidence that operating infrastructure which automatically handles
+third-party information is a legally recognized role, separate from publishing that information.
 
 That said, §512 covers only copyright, and its protections come with conditions, so it is best read
 as a useful precedent rather than a blanket guarantee against legal risk. Legal treatment of network

--- a/hugo-site/content/about/faq/index.md
+++ b/hugo-site/content/about/faq/index.md
@@ -239,10 +239,10 @@ method can work as well or better.
 
 # Is it legal to run a Freenet peer? {#is-it-legal-to-run-a-freenet-peer}
 
-Generally speaking, yes. Running a Freenet peer is like running any other network infrastructure
-that automatically handles other people's traffic, a role many legal systems have long distinguished
-from intentionally publishing material. Running a peer does not mean you endorse or intentionally
-publish every piece of information it may automatically route or cache.
+Running a Freenet peer is like running any other network infrastructure that automatically handles
+other people's traffic, a role many legal systems have long distinguished from intentionally
+publishing material. Running a peer does not mean you endorse or intentionally publish every piece
+of information it may automatically route or cache.
 
 One example comes from U.S. law, used here for illustration rather than as a universal rule:
 [17 U.S.C. §512](https://www.law.cornell.edu/uscode/text/17/512), part of the DMCA. It expressly


### PR DESCRIPTION
## Problem

The peer-legality FAQ entry (added in #107, refined in #108) opens with "Generally speaking, yes." — a universal legal conclusion the project cannot stand behind. Skimmers read and quote the first line in isolation; the entry's supporting evidence is US-copyright-specific, and no court has ruled on how §512 applies to a Freenet peer.

## Approach

Delete the opener sentence. The remaining first line ("Running a Freenet peer is like running any other network infrastructure that automatically handles other people's traffic...") answers the headline's spirit — this is a normal, legally recognized activity — without asserting a legality guarantee. All of #108's jurisdiction wording is preserved. Second commit is a prettier reflow of a pre-existing long paragraph.

Requested by Ian after review discussion (accuracy/perception review of the entry).

## Testing

Hugo builds clean; prettier clean; anchor links unchanged.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMFQxiSpfoUqxrEqQp5JXR