### PR TITLE
docs(quickstart): stop competing with /try/, and link to it

### DIFF
--- a/hugo-site/content/quickstart/_index.md
+++ b/hugo-site/content/quickstart/_index.md
@@ -5,14 +5,14 @@ draft: false
 ---
 
 Install Freenet and you'll join the live chat room where the project's developers and users talk.
-It's the best way to see the network in action.
+It's the best way to see the network for real.
 
 The room runs as a Freenet contract: code that lives across the peer-to-peer network instead of on
 a central server. No company hosts it, no account to make, no admin who can shut it down.
 
 Want to look before installing? [Try River in your browser](/try/), a hosted demo of this same
-room with no download. It runs on a peer we host instead of one on your machine, so your data
-lives with us and it's a preview rather than the real thing.
+room with no download. It runs on a peer we host instead of one on your machine, so it's a
+preview rather than the real thing.
 
 {{< alert type="warning" >}} **Alpha notes:** Freenet is under active development.
 
@@ -56,8 +56,8 @@ system-wide service instead: `sudo freenet service install --system`
 
 **Network requirements:** Freenet uses UDP hole punching for peer-to-peer connections. Most home
 routers support this without configuration. Strict corporate firewalls may block connections. If
-yours does, [River in your browser](/try/) still works, since it reaches the network through a
-peer we host.
+yours does, the [hosted demo](/try/) usually still works, since it reaches the network over HTTPS
+through a peer we host.
 
 Need to remove Freenet? See the [uninstall guide](/uninstall/).
 

--- a/hugo-site/content/quickstart/_index.md
+++ b/hugo-site/content/quickstart/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Try Freenet: Join River"
+title: "Install Freenet: Join River"
 date: 2025-01-01
 draft: false
 ---
@@ -9,6 +9,10 @@ It's the fastest way to see the network in action.
 
 The room runs as a Freenet contract: code that lives across the peer-to-peer network instead of on
 a central server. No company hosts it, no account to make, no admin who can shut it down.
+
+Want to look before installing? [Try River in your browser](/try/), a hosted demo of this same
+room that needs no download. It runs on our server rather than peer-to-peer, so it's a preview
+rather than the real thing.
 
 {{< alert type="warning" >}} **Alpha notes:** Freenet is under active development.
 

--- a/hugo-site/content/quickstart/_index.md
+++ b/hugo-site/content/quickstart/_index.md
@@ -5,14 +5,14 @@ draft: false
 ---
 
 Install Freenet and you'll join the live chat room where the project's developers and users talk.
-It's the fastest way to see the network in action.
+It's the best way to see the network in action.
 
 The room runs as a Freenet contract: code that lives across the peer-to-peer network instead of on
 a central server. No company hosts it, no account to make, no admin who can shut it down.
 
 Want to look before installing? [Try River in your browser](/try/), a hosted demo of this same
-room that needs no download. It runs on our server rather than peer-to-peer, so it's a preview
-rather than the real thing.
+room with no download. It runs on a peer we host instead of one on your machine, so your data
+lives with us and it's a preview rather than the real thing.
 
 {{< alert type="warning" >}} **Alpha notes:** Freenet is under active development.
 
@@ -55,7 +55,9 @@ room name, click **"Leave Room"**, then get a new invite.
 system-wide service instead: `sudo freenet service install --system`
 
 **Network requirements:** Freenet uses UDP hole punching for peer-to-peer connections. Most home
-routers support this without configuration. Strict corporate firewalls may block connections.
+routers support this without configuration. Strict corporate firewalls may block connections. If
+yours does, [River in your browser](/try/) still works, since it reaches the network through a
+peer we host.
 
 Need to remove Freenet? See the [uninstall guide](/uninstall/).
 


### PR DESCRIPTION
## Problem

`/quickstart/` was titled **"Try Freenet: Join River"**, colliding with `/try/` — **"Try Freenet in your browser"**. In a tab strip or a search result the two are near-indistinguishable.

Worse, the link between them was one-way. `/try/` pointed at `/quickstart/` twice; `/quickstart/` pointed at `/try/` **zero** times. Anyone arriving at `/quickstart/` from the nav, a search result, `/apps/`, `/river/` or the manual never learned the no-install option existed — the direction that matters more, since the install page is the one carrying the friction.

Both are leftovers of one-directional editing, not a regression. `/quickstart/` got its title on 2026-05-04 (7e3cb08d), two months before `/try/` existed. The `/try/` work on 2026-07-07 (#68/#69/#70) added the new page and rewired the homepage, but never came back to the older page.

## Approach

- **Title and `<title>` become "Install Freenet: Join River"** — matches the homepage's primary CTA and frees "Try Freenet" for `/try/`. The URL is unchanged, so no redirects and no external links break.
- **A pointer to `/try/` above Step 1**, before the install friction rather than buried in "What's Next?".
- **A second pointer in Troubleshooting**, on the network-requirements note. That was a dead end for exactly the reader `/try/` serves: someone whose firewall blocks UDP hole punching, who has already tried to install and failed.

## Review findings addressed

Two independent blind reviewers ran on this. Both found real problems in copy I had added:

1. **Inaccuracy (fixed in 5381858c).** I had written that the demo runs "on our server rather than peer-to-peer". False. `try.freenet.org` is a Freenet peer we run — it serves the same node-gateway path shape and the same contract key that an installed peer serves at `localhost:7509` (see the default `base` in `river-invite-button.html`). What is centralized is whose peer holds your session, not whether the network is involved. The page was claiming *more* centralization than `/try/` claims for itself.
2. **Unbalanced caveat (fixed in 0f815587).** "your data lives with us" reproduced the alarming half of `/try/`'s framing without the encryption mitigation that follows it there.
3. **Overclaim (fixed in 0f815587).** The firewall note promised the demo "still works", unconditional. River in the browser also needs a WebSocket to the hosted node — another repo, unverified here — and a DPI proxy can block WS upgrades while allowing HTTPS. Now hedged, and says "over HTTPS" so the reason is legible.
4. **Deep-link context loss (fixed in 0f815587).** That sentence didn't say the demo was hosted; someone landing on `#troubleshooting` from a search would read it as the real thing.
5. **Self-contradiction (fixed).** "fastest way to see the network in action" was undercut one paragraph later by a no-download option.

**Not adopted:** propagating `/try/`'s "export your data in one click" claim onto this page. A reviewer proposed it; the same reviewer flagged it as unverified, and I did not verify it either, so it stays on the one page that already asserts it.

## Known-unfixed, deliberately out of scope

Scoped to these two page bodies by direction on the request. Still open afterwards:

- The **nav label is still "Quickstart"** while the page is headed "Install Freenet: Join River". Not a regression (it was equally mismatched before), but the three-way naming problem is only two-thirds solved.
- **`/try/` has no nav entry at all** — it is reachable only from the homepage and now from `/quickstart/`. From any interior page a reader can find Quickstart but not `/try/`.
- **`/river/`'s three "Install Freenet & Join River" CTAs** have no browser option.
- **Link labels for `/try/` still vary site-wide** ("Open River in your browser", "Try River in your browser", "hosted demo", and `/try/`'s own H1 "Try Freenet in your browser").

## Testing

- `cargo make check-links` on a clean build: self-test passes (17/17 expected failures detected), no broken internal links across 222 pages. Both `/try/` links and the final wording confirmed present in the built HTML.
- Screenshotted at 1280px and 390px.
- A reviewer independently built `origin/main` and `HEAD` into separate trees and diffed them: exactly two output files change (`quickstart/index.html`, `quickstart/feed.xml`), confirming the title rename has no wider blast radius — sitemap byte-identical, no OpenGraph/meta consumers, menu name hardcoded.

Not covered by automation: this is prose, so the wording is a judgment call rather than something CI can assert.

[AI-assisted - Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBzsn4BUH4dHQ9gMHSGj2P