### PR TITLE
feat(homepage): surface Ghost Keys in the For Supporters card

### DIFF
--- a/hugo-site/content/_index.md
+++ b/hugo-site/content/_index.md
@@ -83,10 +83,12 @@ maintain, no cloud bills, no terms of service.
 
 ## For Supporters
 
-Freenet is built by a small team, funded through grants and donations. Your support helps build
-decentralized internet infrastructure that matters.
+Freenet is built by a small team, funded through grants and donations. Donating can also issue you a
+Ghost Key, an anonymous identity that works across Freenet apps.
 
 <a href="/donate/" class="funding-learn-more">Support Freenet →</a>
+
+<a href="/ghostkey/" class="funding-learn-more">Get a Ghost Key →</a>
 
 </div>
 


### PR DESCRIPTION
## Problem

Ghost Keys are unreachable from the homepage. The nav **Donate** button goes to `/donate/`, which links on to `/ghostkey/` since #93, but nothing on the front page itself mentions them.

The constraint when we discussed this was that the homepage is already arguably too busy, so the fix shouldn't add weight.

## Approach

It doesn't add any. The **For Supporters** card carried one link against two in each of its neighbours, with visible empty space below it:

| card | links before | links after |
|---|---|---|
| For Users | 2 | 2 |
| For Developers | 2 | 2 |
| For Supporters | **1** | 2 |

Filling that existing gap balances the row. **Rendered page height is unchanged at 1944px** on desktop.

The card's second sentence ("Your support helps build decentralized internet infrastructure that matters") was generic filler, so it makes way for a concrete one that also explains the new link. Without that, "Ghost Key" arrives as unexplained jargon on the front page.

## Testing

`hugo` build clean. Verified in Chromium at 1280 and 390 wide: exactly one `/ghostkey/` link on the page, desktop height unchanged at 1944px, and the three cards render evenly.

## Note on framing

We'd discussed a "membership" reframe and recurring billing, which would change this copy. Neither is built, so this describes what actually exists today: a one-time donation that issues a key. Worth revisiting the wording if the recurring model ever lands.

[AI-assisted - Claude]