### PR TITLE
docs(api): write down the gkapi deploy procedure, including setcap

### DIFF
--- a/rust/api/README.md
+++ b/rust/api/README.md
@@ -2,6 +2,99 @@
 
 WARNING: This file is publicly readable, do NOT put anything secret in here.
 
+## Deploying gkapi
+
+There is **no CI deployment for this crate**. `deploy.yml` builds the Hugo site and
+publishes it to GitHub Pages; it never touches the API. `rust-api-tests.yml` only runs
+fmt, build and test. Merging a change to `rust/api` therefore ships nothing: the binary
+on vega has to be replaced by hand, and has in the past sat months behind main.
+
+There is also no Rust toolchain on vega (`~gkapi/.cargo` exists but `bin/` is empty), so
+the binary is built elsewhere and copied. vega and nova are both Ubuntu 24.04 on the same
+glibc, so a release build from nova runs there as-is. Check with `ldd --version` on both
+before relying on that.
+
+### The step that is easy to miss
+
+The service runs as the unprivileged `gkapi` user and binds **port 80** for the HTTP-01
+ACME challenge server, which needs `CAP_NET_BIND_SERVICE`. That capability lives on the
+binary as a file capability, and **`cp` does not preserve it**. Replace the binary without
+re-running `setcap` and the service binds 443, logs `Listening on 0.0.0.0:443`, then panics
+at `main.rs` with `PermissionDenied` on the port 80 bind and systemd restart-loops until it
+gives up.
+
+The same trap catches the rollback: copying a backup *back* into place also produces a file
+with no capability, so a panicking service stays panicking and it looks like the new build
+is at fault. `mv` preserves the capability because it keeps the inode; `cp` does not.
+
+### Procedure
+
+```bash
+# 1. build on nova, from main, and prove the build contains what you expect
+cd ~/code/freenet/web/main/rust && cargo build --release -p ghostkey-api
+strings target/release/ghostkey-api | grep -c payment_claim   # sanity: expect non-zero
+
+# 2. upload and re-check after transfer
+scp target/release/ghostkey-api vega:/tmp/ghostkey-api.new
+ssh vega 'strings /tmp/ghostkey-api.new | grep -q payment_claim && echo ok'
+
+# 3. back up with mv (keeps the capability on the backup, so rollback is clean)
+ssh vega 'sudo mv /home/gkapi/bin/ghostkey-api \
+                  /home/gkapi/bin/ghostkey-api.rollback-$(date +%Y%m%d-%H%M%S)'
+
+# 4. install, own, and RESTORE THE CAPABILITY before restarting
+ssh vega '
+  sudo cp /tmp/ghostkey-api.new /home/gkapi/bin/ghostkey-api
+  sudo chown gkapi:gkapi /home/gkapi/bin/ghostkey-api
+  sudo chmod 775 /home/gkapi/bin/ghostkey-api
+  sudo setcap cap_net_bind_service+ep /home/gkapi/bin/ghostkey-api
+  getcap /home/gkapi/bin/ghostkey-api          # must print cap_net_bind_service=ep
+'
+
+# 5. only then restart
+ssh vega 'sudo systemctl reset-failed gkapi && sudo systemctl restart gkapi'
+```
+
+Verify `getcap` prints the capability **before** restarting. If it is empty, fix it rather
+than restarting to see what happens.
+
+### Verifying a deploy
+
+```bash
+ssh vega 'systemctl is-active gkapi; strings /home/gkapi/bin/ghostkey-api | grep -c payment_claim'
+curl -s https://gkapi.freenet.org/                       # {"message":"Hello, world!"}
+curl -s -o /dev/null -w '%{http_code}\n' http://gkapi.freenet.org/.well-known/acme-challenge/probe
+```
+
+That last one matters: a 404 means the port 80 challenge listener is up. Connection refused
+means the capability is missing and certificate renewal will fail at the next attempt even
+if HTTPS looks healthy.
+
+Then confirm every donation tier still resolves its notary keypair, which is a separate
+failure mode from the binary (see the tier comment in
+`hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html`):
+
+```bash
+for a in 1 5 20 50 100 500 2500 10000; do
+  curl -s -X POST https://gkapi.freenet.org/create-donation \
+    -H 'Content-Type: application/json' -d "{\"amount\":$((a*100)),\"currency\":\"usd\"}" \
+  | grep -q notary_certificate_base64 && echo "\$$a ok" || echo "\$$a FAIL"
+done
+```
+
+### Rollback
+
+```bash
+ssh vega '
+  sudo cp /home/gkapi/bin/ghostkey-api.rollback-<stamp> /home/gkapi/bin/ghostkey-api
+  sudo chown gkapi:gkapi /home/gkapi/bin/ghostkey-api
+  sudo setcap cap_net_bind_service+ep /home/gkapi/bin/ghostkey-api
+  sudo systemctl reset-failed gkapi && sudo systemctl restart gkapi
+'
+```
+
+The `setcap` line is required on the way back too, for the reason above.
+
 ## letsencrypt
 
 Verify that certificate was automatically renewed by root cron job on vega by looking at write times

--- a/rust/api/README.md
+++ b/rust/api/README.md
@@ -38,25 +38,45 @@ strings target/release/ghostkey-api | grep -c payment_claim   # sanity: expect n
 scp target/release/ghostkey-api vega:/tmp/ghostkey-api.new
 ssh vega 'strings /tmp/ghostkey-api.new | grep -q payment_claim && echo ok'
 
-# 3. back up with mv (keeps the capability on the backup, so rollback is clean)
-ssh vega 'sudo mv /home/gkapi/bin/ghostkey-api \
-                  /home/gkapi/bin/ghostkey-api.rollback-$(date +%Y%m%d-%H%M%S)'
-
-# 4. install, own, and RESTORE THE CAPABILITY before restarting
+# 3. stage it at its final location, fully prepared, WITHOUT displacing the live binary
 ssh vega '
-  sudo cp /tmp/ghostkey-api.new /home/gkapi/bin/ghostkey-api
-  sudo chown gkapi:gkapi /home/gkapi/bin/ghostkey-api
-  sudo chmod 775 /home/gkapi/bin/ghostkey-api
-  sudo setcap cap_net_bind_service+ep /home/gkapi/bin/ghostkey-api
-  getcap /home/gkapi/bin/ghostkey-api          # must print cap_net_bind_service=ep
+  sudo cp /tmp/ghostkey-api.new /home/gkapi/bin/ghostkey-api.staged
+  sudo chown gkapi:gkapi        /home/gkapi/bin/ghostkey-api.staged
+  sudo chmod 775                /home/gkapi/bin/ghostkey-api.staged
+  sudo setcap cap_net_bind_service+ep /home/gkapi/bin/ghostkey-api.staged
+  sudo getcap /home/gkapi/bin/ghostkey-api.staged
 '
+# Must print: /home/gkapi/bin/ghostkey-api.staged cap_net_bind_service=ep
+# If it does not, STOP. Nothing has changed yet and the live binary is untouched.
 
-# 5. only then restart
-ssh vega 'sudo systemctl reset-failed gkapi && sudo systemctl restart gkapi'
+# 4. swap with two adjacent renames, then restart
+ssh vega '
+  set -e
+  STAMP=$(date +%Y%m%d-%H%M%S)
+  sudo mv /home/gkapi/bin/ghostkey-api         /home/gkapi/bin/ghostkey-api.rollback-$STAMP
+  sudo mv /home/gkapi/bin/ghostkey-api.staged  /home/gkapi/bin/ghostkey-api
+  echo "rollback binary: /home/gkapi/bin/ghostkey-api.rollback-$STAMP"
+  sudo systemctl reset-failed gkapi
+  sudo systemctl restart gkapi
+'
 ```
 
-Verify `getcap` prints the capability **before** restarting. If it is empty, fix it rather
-than restarting to see what happens.
+Two things about that shape are deliberate, and both exist to avoid a worse failure than
+the one being fixed:
+
+- **Prepare the capability on the staged file, and verify it, before anything is
+  displaced.** The `getcap` gate in step 3 is the whole point of splitting the steps: if it
+  fails you stop with the running service completely untouched. Do not restart to see what
+  happens.
+- **Do not `mv` the old binary away in one command and `cp` the new one in with another.**
+  Between those two the path does not exist, and anything that restarts the unit in that
+  window (a crash, an OOM, a reboot, someone running `systemctl restart` out of order) fails
+  with `status=203/EXEC` and stays down. Step 4 closes that to two adjacent renames.
+  `mv` is also what carries the capability across, since it keeps the inode.
+
+`sudo` on `getcap` is not decoration: it lives in `/usr/sbin`, which is not on a normal
+user's `PATH`, so a bare `getcap` can fail as "command not found" and skip the check
+entirely.
 
 ### Verifying a deploy
 
@@ -72,7 +92,12 @@ if HTTPS looks healthy.
 
 Then confirm every donation tier still resolves its notary keypair, which is a separate
 failure mode from the binary (see the tier comment in
-`hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html`):
+`hugo-site/themes/freenet/layouts/shortcodes/stripe-donation-form.html`).
+
+Note that `/create-donation` has no dry-run mode: each call creates a real PaymentIntent in
+the live Stripe account. Nothing is charged and no card is attached, so these are harmless
+abandoned intents, exactly what a visitor clicking between the amount radios produces. Run
+the loop once after a deploy; do not wrap it in a retry-until-success script.
 
 ```bash
 for a in 1 5 20 50 100 500 2500 10000; do
@@ -84,16 +109,26 @@ done
 
 ### Rollback
 
+Substitute `<stamp>` with the timestamp step 4 printed.
+
 ```bash
 ssh vega '
-  sudo cp /home/gkapi/bin/ghostkey-api.rollback-<stamp> /home/gkapi/bin/ghostkey-api
-  sudo chown gkapi:gkapi /home/gkapi/bin/ghostkey-api
-  sudo setcap cap_net_bind_service+ep /home/gkapi/bin/ghostkey-api
+  set -e
+  sudo cp /home/gkapi/bin/ghostkey-api.rollback-<stamp> /home/gkapi/bin/ghostkey-api.staged
+  sudo chown gkapi:gkapi /home/gkapi/bin/ghostkey-api.staged
+  sudo chmod 775 /home/gkapi/bin/ghostkey-api.staged
+  sudo setcap cap_net_bind_service+ep /home/gkapi/bin/ghostkey-api.staged
+  sudo getcap /home/gkapi/bin/ghostkey-api.staged
+  sudo mv /home/gkapi/bin/ghostkey-api.staged /home/gkapi/bin/ghostkey-api
   sudo systemctl reset-failed gkapi && sudo systemctl restart gkapi
 '
 ```
 
-The `setcap` line is required on the way back too, for the reason above.
+The `setcap` line is required on the way back too, and this is the part that is genuinely
+easy to get wrong under pressure: copying a backup *into place* produces a file with no
+capability, so the service carries on panicking and it reads as "the new build is broken"
+rather than "the copy dropped a capability". If a rollback does not fix the panic, run
+`sudo getcap` on the live binary before concluding anything about the build.
 
 ## letsencrypt
 


### PR DESCRIPTION
## Problem

Deploying `gkapi` is undocumented, and one step in it is invisible until it bites.

The service runs as the unprivileged `gkapi` user and binds **port 80** for the HTTP-01 ACME challenge server, which needs `CAP_NET_BIND_SERVICE` as a file capability on the binary. **`cp` does not preserve file capabilities.** Replace the binary without re-running `setcap` and it binds 443, logs a healthy-looking `Listening on 0.0.0.0:443`, then panics with `PermissionDenied` on the port 80 bind and systemd restart-loops until it gives up.

What makes it genuinely nasty is that **the same trap catches the rollback**: copying a backup *back* into place also produces a file with no capability, so the service keeps panicking and it reads as "the new build is broken" rather than "the copy dropped a capability". `mv` keeps the inode and therefore the capability; `cp` does not.

This bit while deploying #94 and took the API down for about 100 seconds (16:27:05 to 16:28:45 UTC, 2026-08-16). Diagnosis was only obvious once `getcap` was compared between the backup (which had `cap_net_bind_service=ep`, because it was created with `mv`) and the installed binary (which had nothing).

## Also recorded

- **Merging a change to `rust/api` ships nothing.** `deploy.yml` builds the Hugo site and publishes to GitHub Pages; it never touches the API. `rust-api-tests.yml` only runs fmt/build/test. #94 sat merged and undeployed for 18 days for exactly this reason, and nothing in the repo said so.
- **There is no Rust toolchain on vega** (`~gkapi/.cargo` exists but `bin/` is empty), so the binary is built elsewhere and copied. vega and nova are both Ubuntu 24.04 on identical glibc, which is what makes that safe.
- A verification step that would have caught this immediately: `curl http://gkapi.freenet.org/.well-known/acme-challenge/probe` should return 404. Connection refused means the capability is missing, and **certificate renewal will fail at the next attempt even though HTTPS looks perfectly healthy**. That is the part that would have turned a 100-second outage into a surprise expiry weeks later.
- Tier verification, since a missing notary keypair is a separate failure mode from the binary.

## Testing

Documentation only, no code. Every command in it was run against vega during the #94 deploy and the recovery.

## Not addressed

The real fix is CI deployment for this crate so the manual procedure stops mattering. That is a bigger change and wants its own discussion, so this just makes the manual path safe and writes down that the gap exists.

[AI-assisted - Claude]