### PR TITLE
feat(donate): balance PayPal and Ghost Keys CTAs

### DIFF
--- a/hugo-site/content/donate/_index.md
+++ b/hugo-site/content/donate/_index.md
@@ -62,18 +62,20 @@ If you are interested in supporting Freenet at a significant level, we would be 
 
 <div class="funding-section funding-donate-section">
 
-## Donate
+## Donate via PayPal
 
 <a href="https://www.paypal.com/donate?hosted_button_id=EQ9E7DPHB6ETY" class="funding-donate-button">Donate via PayPal</a>
 
+<p class="gk-cta-note">One-time or recurring, no account required.</p>
+
 </div>
 
-<div class="funding-section funding-ghost-keys">
+<div class="funding-section funding-donate-section funding-ghost-keys">
 
-## Donating by card
+## Donate via card
 
-If you would rather give by card, you can donate through [Ghost Keys](/ghostkey/). A Ghost Key is an
-anonymous cryptographic identity, issued with your donation, that works across Freenet apps and
-cannot be linked back to your payment. The minimum is $1.
+<a href="/ghostkey/create/" class="funding-donate-button">Donate via card</a>
+
+<p class="gk-cta-note">Issues a <a href="/ghostkey/">Ghost Key</a>, an anonymous cryptographic identity that works across Freenet apps and can't be linked back to your payment. $1 minimum.</p>
 
 </div>

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -1311,20 +1311,12 @@ picture.app-screenshot img {
   }
 }
 
-/* Ghost keys — understated */
+/* Ghost Keys donate option — same visual weight as PayPal (funding-donate-button
+   + gk-cta-note), just separated from it with a divider so the two read as
+   distinct, equally-weighted choices rather than one continuous block. */
 .funding-ghost-keys {
   padding-top: 1.5rem;
   border-top: 1px solid rgba(0, 0, 0, 0.08);
-}
-
-.funding-ghost-keys h2 {
-  font-size: 1.15rem;
-  color: #64748b;
-}
-
-.funding-ghost-keys p {
-  color: #64748b;
-  font-size: 0.95rem;
 }
 
 /* Dark mode — funding page */
@@ -1375,14 +1367,6 @@ picture.app-screenshot img {
 
   .funding-ghost-keys {
     border-top-color: rgba(255, 255, 255, 0.08);
-  }
-
-  .funding-ghost-keys h2 {
-    color: #8896a8;
-  }
-
-  .funding-ghost-keys p {
-    color: #8896a8;
   }
 }
 


### PR DESCRIPTION
## Problem

The donate page offered two ways to give, but they had wildly unequal visual weight:

1. **PayPal** — a full-size `## Donate` heading + a filled primary button (`.funding-donate-button`).
2. **Ghost Keys (card via Stripe)** — no button at all, just a smaller greyed heading and a muted grey paragraph with an inline text link. `.funding-ghost-keys` deliberately shrank the heading (1.15rem, `#64748b`) and paragraph (0.95rem, `#64748b`).

This was intentional in a prior PR (understated Ghost Keys treatment), but the direction is being reversed: both are legitimate, genuinely different ways to donate, and should read as an equal choice, not a primary option and an afterthought.

## Approach

Gave the card option the same visual treatment as PayPal, reusing existing patterns rather than inventing new ones:

- Matching heading style for both (`## Donate via PayPal` / `## Donate via card`), same size/color in both themes.
- A real button for the card option using `.funding-donate-button` — the same class already used for Ghost Key CTAs on `/ghostkey/`, so no new button style was introduced. Links to `/ghostkey/create/`, the actual entry point used elsewhere on the site.
- A one-line note under **both** buttons (`.gk-cta-note`, already used on `/ghostkey/`), rather than a caption under only one — this keeps the fine print an equal-weight explainer on each side instead of a marker for the "lesser" option.
- Stripped `.funding-ghost-keys`'s heading/paragraph color and font-size overrides; kept only the top divider that visually separates the two options.

Deliberately avoided: urgency, scarcity, pre-selecting one option, or guilt-framed copy on either side. Neither option is styled as the "recommended" or "default" choice.

`funding-ghost-keys` is only referenced in `donate/_index.md` (checked via grep before editing its rules), so this doesn't affect any other page.

## Testing

Built with `hugo --quiet` (clean, no warnings/errors). Screenshotted and measured with Playwright at desktop (1280x900) and mobile (390x844), both light and dark color schemes, before and after.

Before (live site, desktop):
- PayPal: heading 25.2px tall (1.4rem, `#1a1a2e`), button 195x52
- Ghost Keys: heading 20.7px tall (1.15rem, `#64748b`), **no button**, plain paragraph 79.8px tall

After (this branch, desktop, both themes):
- PayPal heading: 22.4px font-size, `rgb(26,26,46)` light / `rgb(232,232,232)` dark
- Card heading: 22.4px font-size, **same colors** — identical to PayPal
- PayPal button: 195x52, `rgb(0,102,204)` background, 16px font
- Card button: 177x52 (width differs only because "Donate via card" vs "Donate via PayPal" is a different label length), **same background, height, and font-size**
- Both notes: 14.4px font-size, same color

Verified visually in all 4 combinations (desktop/mobile x light/dark) by reading the rendered screenshots, not just the numbers.

Closes the visual-parity request from Ian.

[AI-assisted - Claude]
