### PR TITLE
feat(donate): balance and surface the donate CTAs

### DIFF
--- a/hugo-site/content/donate/_index.md
+++ b/hugo-site/content/donate/_index.md
@@ -11,6 +11,21 @@ Freenet is a long-term effort to build decentralized infrastructure for a free a
 Development is funded primarily by donations and grants from individuals who believe this work
 matters.
 </p>
+
+<div class="funding-hero-donate">
+
+<div class="funding-hero-donate-option">
+<a href="https://www.paypal.com/donate?hosted_button_id=EQ9E7DPHB6ETY" class="funding-donate-button">Donate via PayPal</a>
+<p class="gk-cta-note">One-time or recurring, no account required.</p>
+</div>
+
+<div class="funding-hero-donate-option">
+<a href="/ghostkey/create/" class="funding-donate-button">Donate via card</a>
+<p class="gk-cta-note">Issues a <a href="/ghostkey/">Ghost Key</a>, an anonymous cryptographic identity that works across Freenet apps and can't be linked back to your payment. $1 minimum.</p>
+</div>
+
+</div>
+
 </div>
 
 <div class="funding-section">

--- a/hugo-site/content/donate/_index.md
+++ b/hugo-site/content/donate/_index.md
@@ -62,18 +62,20 @@ If you are interested in supporting Freenet at a significant level, we would be 
 
 <div class="funding-section funding-donate-section">
 
-## Donate
+## Donate via PayPal
 
 <a href="https://www.paypal.com/donate?hosted_button_id=EQ9E7DPHB6ETY" class="funding-donate-button">Donate via PayPal</a>
 
+<p class="gk-cta-note">One-time or recurring, no account required.</p>
+
 </div>
 
-<div class="funding-section funding-ghost-keys">
+<div class="funding-section funding-donate-section funding-ghost-keys">
 
-## Donating by card
+## Donate via card
 
-If you would rather give by card, you can donate through [Ghost Keys](/ghostkey/). A Ghost Key is an
-anonymous cryptographic identity, issued with your donation, that works across Freenet apps and
-cannot be linked back to your payment. The minimum is $1.
+<a href="/ghostkey/create/" class="funding-donate-button">Donate via card</a>
+
+<p class="gk-cta-note">Issues a <a href="/ghostkey/">Ghost Key</a>, an anonymous cryptographic identity that works across Freenet apps and can't be linked back to your payment. $1 minimum.</p>
 
 </div>

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -1193,6 +1193,27 @@ picture.app-screenshot img {
   max-width: 640px;
 }
 
+/* Donate options, surfaced right under the hero lead so a visitor who already
+   decided to give (they clicked "Donate" in the nav) can act immediately,
+   without scrolling past "Why Freenet matters" / "About the project" /
+   "Major supporters" first. Two equally-weighted columns; wraps to a single
+   column on narrow viewports. The prose stays below unchanged, and the same
+   two options repeat at the bottom of the page for anyone who scrolls down
+   to read first — see .funding-donate-section. */
+.funding-hero-donate {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.5rem 3rem;
+  margin-top: 2rem;
+}
+
+.funding-hero-donate-option {
+  flex: 1 1 240px;
+  max-width: 300px;
+  text-align: center;
+}
+
 .funding-section {
   margin-bottom: 2.5rem;
 }
@@ -1259,6 +1280,12 @@ picture.app-screenshot img {
 .funding-donate-button {
   display: inline-block;
   padding: 0.75rem 2rem;
+  /* Explicit rather than inherited: this button now renders inside both a
+     bare <p> (bottom donate sections) and a raw-HTML div with no <p> wrapper
+     (hero CTA), which without this rule pick up different ambient
+     line-heights from their parents and render at different heights.
+     Pinning it here keeps every instance of the button pixel-identical. */
+  line-height: 1.5;
   background: var(--color-primary);
   color: #ffffff !important;
   text-decoration: none !important;

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -1311,20 +1311,12 @@ picture.app-screenshot img {
   }
 }
 
-/* Ghost keys — understated */
+/* Ghost Keys donate option — same visual weight as PayPal (funding-donate-button
+   + gk-cta-note), just separated from it with a divider so the two read as
+   distinct, equally-weighted choices rather than one continuous block. */
 .funding-ghost-keys {
   padding-top: 1.5rem;
   border-top: 1px solid rgba(0, 0, 0, 0.08);
-}
-
-.funding-ghost-keys h2 {
-  font-size: 1.15rem;
-  color: #64748b;
-}
-
-.funding-ghost-keys p {
-  color: #64748b;
-  font-size: 0.95rem;
 }
 
 /* Dark mode — funding page */
@@ -1375,14 +1367,6 @@ picture.app-screenshot img {
 
   .funding-ghost-keys {
     border-top-color: rgba(255, 255, 255, 0.08);
-  }
-
-  .funding-ghost-keys h2 {
-    color: #8896a8;
-  }
-
-  .funding-ghost-keys p {
-    color: #8896a8;
   }
 }
 

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -1318,7 +1318,14 @@ picture.app-screenshot img {
   text-align: center;
 }
 
-.gk-cta-note {
+/* Doubled selector deliberately raises specificity to (0,2,0). .gk-cta-note
+   is a <p>, so a plain single-class selector here (0,1,0) loses outright to
+   `.funding-section p` (0,1,1) whenever a note is nested inside a
+   .funding-section container (donate page's bottom CTAs, hero CTA row) — the
+   note silently rendered a different color than on /ghostkey/. Do not drop
+   this back to plain `.gk-cta-note`; that reintroduces the bug regardless of
+   source order in the file (see PR #117 review). */
+.gk-cta-note.gk-cta-note {
   margin: 0.75rem auto 0 auto;
   max-width: 34rem;
   font-size: 0.9rem;
@@ -1333,7 +1340,7 @@ picture.app-screenshot img {
 }
 
 @media (prefers-color-scheme: dark) {
-  .gk-cta-note {
+  .gk-cta-note.gk-cta-note {
     color: #94a3b8;
   }
 }


### PR DESCRIPTION
## Problem

Two issues with the donate page's CTAs:

1. **Unequal visual weight.** PayPal got a full-size `## Donate` heading and a filled primary button. Ghost Keys (card via Stripe) was a muted grey paragraph with an inline text link and no button at all.
2. **Both below the fold, on every viewport.** They sat under "Why Freenet matters", "About the project", and "Major supporters" — 71-81% down the page on desktop, 74-81% down on mobile. A visitor on `/donate/` already decided to give (they clicked "Donate" in the nav); making a decided donor scroll past three sections of persuasion before they can act is friction, the same mistake fixed on `/ghostkey/` in PR #93.

## Approach

**Symmetry:** gave the card option the same treatment as PayPal, reusing existing patterns:
- Matching headings (`## Donate via PayPal` / `## Donate via card`), same size/color in both themes.
- A real button for the card option using `.funding-donate-button` — the same class already used for Ghost Key CTAs on `/ghostkey/`. Links to `/ghostkey/create/`, the existing entry point.
- A one-line note under **both** buttons (`.gk-cta-note`), not just one, so the fine print doesn't itself mark one option as "the lesser choice."
- Stripped `.funding-ghost-keys`'s color/size overrides, kept only the divider.

**Above the fold:** added a two-column CTA row right after the hero lead paragraph — same heading/button/note treatment as the bottom section, which stays in place unchanged (a second chance for anyone who reads the mission/major-supporters content first, per the pattern already established on `/ghostkey/`). No escalating language on the repeat; wording is identical top and bottom. "Why Freenet matters", "About the project", and "Major supporters" are untouched.

**Pixel parity fix:** discovered while measuring that the hero button (bare `<div>`, no `<p>` wrapper) and the bottom button (wrapped in a `<p>` that inherits `.funding-section p`'s `line-height: 1.75`) rendered 4px apart in height purely from ambient context. Pinned `line-height: 1.5` explicitly on `.funding-donate-button` so every instance is pixel-identical regardless of where it's placed. This is a deliberate, shared normalization: it also changes `/ghostkey/`'s three existing buttons from 49.59px to 48px tall (page 6px shorter overall), imperceptible at normal zoom, and intentional — `.funding-donate-button` is now consistent across both pages, so a future change to its line-height is a real cross-page change, not a local one.

No dark patterns: no urgency, scarcity, pre-selection, or guilt-framed copy on either option.

## Testing

Built with `hugo --quiet` (clean). Verified with Playwright at desktop (1280x900) and mobile (390x844), light and dark, before and after — read every screenshot, not just the numbers.

**Position (desktop / mobile, "% down the page"):**
| | before | after |
|---|---|---|
| PayPal button | 71% / 74% (below fold) | **16% / 16% (above fold)** |
| Card button | 79% / 81% (below fold) | **16% / 20% (above fold)** |

Both hero CTAs land inside the first viewport on both desktop and mobile.

**Balance (desktop, both themes, all 4 button instances — hero x2 + bottom repeat x2):**
- All four: 48px tall, 24px line-height, 16px font, `rgb(0,102,204)` background — identical
- Headings: 22.4px font-size, same color per theme (`rgb(26,26,46)` light / `rgb(232,232,232)` dark) on both PayPal and card sections
- Notes: 14.4px font-size, same color, present under both options in both places

Button width differs only by label length (195px "Donate via PayPal" vs 177px "Donate via card").

## Update: review findings addressed

Independent review (thanks!) caught a real bug and one inaccurate claim above, both fixed in a follow-up commit:

- **Bug:** the "same color" claim for notes was wrong. `.gk-cta-note` (specificity 0,1,0) was silently losing to `.funding-section p` (specificity 0,1,1) whenever a note landed inside a `.funding-section` container — which the hero row and bottom sections both are, but `/ghostkey/`'s notes never were. Measured: `rgb(100,116,139)` on /ghostkey/ vs `rgb(55,65,81)` in the donate page's bottom sections (light), and the equivalent pair in dark. Fixed with `.gk-cta-note.gk-cta-note` (specificity 0,2,0), which wins outright regardless of file order — commented so it isn't "simplified" back to a single class. Re-measured after the fix: all 8 note instances across both pages (donate hero x2, donate bottom x2, ghostkey x4) now report the identical computed color per theme.
- **Inaccurate claim, corrected above:** the line-height pin does change `/ghostkey/`'s buttons (49.59px → 48px), not "doesn't visibly change" as originally stated. It's kept as a deliberate, imperceptible, cross-page normalization — see the corrected paragraph above.

Not changed, per reviewer + my agreement: the note-length asymmetry (PayPal one line, card three) is content-driven — a Ghost Key genuinely needs more explanation — and the buttons, which carry the actual decision, are identical.

Closes the visual-parity and above-the-fold requests from Ian.

[AI-assisted - Claude]

