### PR TITLE
docs: fix broken River sync module link in the tutorial

### DIFF
--- a/hugo-site/content/build/manual/tutorial.md
+++ b/hugo-site/content/build/manual/tutorial.md
@@ -443,8 +443,10 @@ fn App() -> Element {
 ### Connecting to Freenet
 
 River's UI communicates with the kernel through a WebSocket API. See
-[River's sync module](https://github.com/freenet/river/tree/main/ui/src/sync) for the complete
-implementation pattern.
+[River's `freenet_api` module](https://github.com/freenet/river/tree/main/ui/src/components/app/freenet_api)
+for the complete implementation pattern: `connection_manager.rs` opens and reconnects the socket,
+`freenet_synchronizer.rs` drives the sync loop, `room_synchronizer.rs` maps rooms onto contract
+GET/PUT/SUBSCRIBE/UPDATE, and `response_handler/` handles each kind of node response.
 
 ---
 


### PR DESCRIPTION
## Problem

Err0rz asked on Matrix what happened to River's sync module, because the app-building tutorial links to it:

> https://github.com/freenet/river/tree/main/ui/src/sync

That URL 404s. Investigating: the path has **never existed** in River's git history — `git log --all --name-only` across every commit shows no `ui/src/sync`, and at the commit contemporaneous with the doc line (Jan 2026) `ui/src/` contained only `components/`, `util/`, and a handful of `.rs` files. So this is a doc error introduced in `7e6dc1f` (2026-01-17, "Remove JS/TS UI example, focus on Dioxus/Rust"), not a River refactor that broke a previously-good link.

Nothing is missing from River. The code the tutorial means to point at is at `ui/src/components/app/freenet_api/`.

## Approach

Repoint the link and, while there, name the files a reader actually needs so the link is useful rather than merely non-404. Descriptions verified against River `main` (419d013):

- `connection_manager.rs` — the only file calling `WebApi::start`/`WebSocket::new`
- `freenet_synchronizer.rs` — the sync loop / orchestrator
- `room_synchronizer.rs` — issues `ContractRequest::{Get,Put,Subscribe,Update}`
- `response_handler/` — one module per response kind

It was the only broken `github.com/freenet/river` link in `content/build/` (the other five all resolve).

## Testing

`hugo` builds clean; confirmed the rendered `build/manual/tutorial/index.html` carries the new href. Both URLs checked over HTTP: old path `404`, new path `200`.

[AI-assisted - Claude]