### PR TITLE
feat: give users a signposted route to report a bug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We welcome contributions to Freenet! Here's what you need to know.
 
 - **Claim the issue first.** Comment on the issue you want to work on and wait for a maintainer to confirm before starting work. This prevents duplicate effort and ensures the approach is aligned with project direction.
 - **Read the codebase conventions.** See [AGENTS.md](AGENTS.md) for project structure, coding standards, and testing requirements.
-- **Ask questions.** If something is unclear, ask on the issue or in our [Matrix channel](https://matrix.to/#/#freenet:matrix.org) before writing code.
+- **Ask questions.** If something is unclear, ask on the issue or in our [Matrix channel](https://matrix.to/#/#freenet-locutus:matrix.org) before writing code.
 
 ## Quality Standards
 
@@ -31,7 +31,7 @@ We require the use of a frontier-class model (as of early 2026: Claude Opus 4, G
 
 ## Getting Help
 
-- [Matrix chat](https://matrix.to/#/#freenet:matrix.org) for questions and discussion
+- [Matrix chat](https://matrix.to/#/#freenet-locutus:matrix.org) for questions and discussion
 - [Issue tracker](https://github.com/freenet/freenet-core/issues) for bugs and feature requests
 - [API docs](https://docs.rs/freenet) for code reference
 - [Freenet manual](https://freenet.org/resources/manual/) for architecture overview

--- a/hugo-site/content/_index.md
+++ b/hugo-site/content/_index.md
@@ -131,6 +131,7 @@ just a few hops, scaling efficiently to millions of peers, no servers required.
 
 [River](/river/) · [Apps](/apps/) · [Video Talks](/about/video-talks/) ·
 [Matrix Chat](https://matrix.to/#/#freenet-locutus:matrix.org) ·
-[GitHub](https://github.com/freenet/freenet-core) · [FAQ](/about/faq/)
+[GitHub](https://github.com/freenet/freenet-core) · [FAQ](/about/faq/) ·
+[Report a Bug](/community/support/)
 
 </div>

--- a/hugo-site/content/build/manual/community.md
+++ b/hugo-site/content/build/manual/community.md
@@ -7,4 +7,4 @@ aliases:
 ---
 
 - [Github](https://github.com/freenet/freenet-core)
-- [Matrix](https://matrix.to/#/#locutus:matrix.org)
+- [Matrix](https://matrix.to/#/#freenet-locutus:matrix.org)

--- a/hugo-site/content/community/_index.md
+++ b/hugo-site/content/community/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Community"
+date: 2026-08-25
+draft: false
+---
+
+[Report a Bug or Get Help](/community/support/) covers where to send a bug report or a feature idea,
+and how to reach us on Matrix.

--- a/hugo-site/content/community/_index.md
+++ b/hugo-site/content/community/_index.md
@@ -3,6 +3,3 @@ title: "Community"
 date: 2026-08-25
 draft: false
 ---
-
-[Report a Bug or Get Help](/community/support/) covers where to send a bug report or a feature idea,
-and how to reach us on Matrix.

--- a/hugo-site/content/community/get-involved/index.md
+++ b/hugo-site/content/community/get-involved/index.md
@@ -1,5 +1,0 @@
----
-title: "Get Involved"
-date: 2024-06-11T00:00:00Z
-draft: false
----

--- a/hugo-site/content/community/support/index.md
+++ b/hugo-site/content/community/support/index.md
@@ -1,5 +1,107 @@
 ---
-title: "Support"
-date: 2024-06-11T00:00:00Z
+title: "Report a Bug or Get Help"
+description:
+  "Where to report a Freenet bug or ask for a feature: which project, which issue tracker, and what
+  to include."
+date: 2026-08-25
 draft: false
+aliases:
+  - /report/
+  - /community/get-involved/
 ---
+
+Found a bug, or want something Freenet does not do yet? Please tell us. This page points you at the
+right place to say it.
+
+Freenet is a network plus a set of separate apps built on top of it, and each one keeps its own list
+of bugs. So the first step is picking which one you were using. If you pick wrong we will move your
+report for you, so it is not worth agonising over.
+
+{{< alert type="warning" >}} **Filing a report on GitHub needs a free GitHub account.** If you would
+rather not create one, say it in [our Matrix room](https://matrix.to/#/#freenet-locutus:matrix.org)
+instead and someone will file it for you. {{< /alert >}}
+
+## What were you using?
+
+### Group chat (River)
+
+Messages not sending, a room that will not load, an invite that does not work, members missing,
+anything in the chat interface itself.
+
+→ [Report a River bug](https://github.com/freenet/river/issues/new) ·
+[existing River issues](https://github.com/freenet/river/issues)
+
+### Freenet itself
+
+Install or uninstall trouble, the node will not start or will not stay running, no connections, high
+CPU or bandwidth use, the menu bar or system tray icon, errors from the `freenet` command. Anything
+underneath the apps rather than inside one.
+
+→ [Report a Freenet bug](https://github.com/freenet/freenet-core/issues/new) ·
+[existing Freenet issues](https://github.com/freenet/freenet-core/issues)
+
+### This website
+
+A broken link, documentation that is wrong or confusing, a page that will not load, a typo.
+
+→ [Report a website bug](https://github.com/freenet/web/issues/new) ·
+[existing website issues](https://github.com/freenet/web/issues)
+
+### Ghost Keys
+
+Anything about donations, Ghost Key certificates, or the vault.
+
+→ [Report a Ghost Keys bug](https://github.com/freenet/ghostkeys/issues/new) ·
+[existing Ghost Keys issues](https://github.com/freenet/ghostkeys/issues)
+
+### One of the other apps
+
+Delta, Mail, freenet-git, Atlas and the rest each keep their own list. Every app on the
+[apps page](/apps/) links to its own project, and you will find its issues there.
+
+### Not sure
+
+Use the [Freenet issue tracker](https://github.com/freenet/freenet-core/issues/new). It is the one
+the maintainers watch most closely, and they will move your report if it belongs somewhere else.
+Describing clearly what happened matters far more than landing it in the right place first time.
+
+If you would rather have someone work it out with you, ask in
+[Matrix](https://matrix.to/#/#freenet-locutus:matrix.org).
+
+## What to put in a bug report
+
+You do not need to diagnose the problem. These are what make a report easy to act on:
+
+- What you were doing, what you expected, and what happened instead.
+- Whether it happens every time or only sometimes.
+- Your operating system, and how you installed Freenet.
+- A screenshot, if it is something you can see.
+
+### The quick way to gather diagnostics
+
+If Freenet is installed on your machine, run this in a terminal:
+
+```bash
+freenet service report
+```
+
+It asks you to describe the problem, gathers your version, operating system, recent log entries and
+configuration, uploads them, and prints a short **report code** that looks like `X7K2M9`. Put that
+code in your bug report and the maintainers can pull up everything they need.
+
+That upload includes recent log lines and your Freenet configuration file. If you would rather see
+what is in it first, `freenet service report --local report.json` writes it to a file on your own
+machine instead of uploading it.
+
+## Prefer to talk to a person?
+
+Our [Matrix room](https://matrix.to/#/#freenet-locutus:matrix.org) is where Freenet's developers and
+users are. It is a good place for "is this even a bug?", for questions the FAQ does not answer, and
+for anything you would rather not write up as a formal report.
+
+## Want to help fix things?
+
+A clear bug report is already a real contribution. If you want to go further, every Freenet project
+takes pull requests and each has a `CONTRIBUTING.md` explaining how, starting with
+[freenet-core](https://github.com/freenet/freenet-core/blob/main/CONTRIBUTING.md). The
+[Build section](/build/) covers how Freenet works and how to write apps for it.

--- a/hugo-site/content/community/support/index.md
+++ b/hugo-site/content/community/support/index.md
@@ -10,31 +10,31 @@ aliases:
   - /community/get-involved/
 ---
 
-Found a bug, or want something Freenet does not do yet? Please tell us. This page points you at the
+Found a bug, or want something Freenet doesn't do yet? Please tell us. This page points you at the
 right place to say it.
 
 Freenet is a network plus a set of separate apps built on top of it, and each one keeps its own list
-of bugs. So the first step is picking which one you were using. If you pick wrong we will move your
-report for you, so it is not worth agonising over.
+of bugs. So the first step is picking which one you were using. If you pick wrong, we'll move your
+report for you.
 
-{{< alert type="warning" >}} **Filing a report on GitHub needs a free GitHub account.** If you would
-rather not create one, say it in [our Matrix room](https://matrix.to/#/#freenet-locutus:matrix.org)
-instead and someone will file it for you. {{< /alert >}}
+Filing a report on GitHub needs a free GitHub account. If you'd rather not create one, say it in
+[our Matrix room](https://matrix.to/#/#freenet-locutus:matrix.org) instead and someone will file it
+for you.
 
 ## What were you using?
 
 ### Group chat (River)
 
-Messages not sending, a room that will not load, an invite that does not work, members missing,
-anything in the chat interface itself.
+Messages not sending, a room that won't load, an invite that doesn't work, members missing, anything
+in the chat interface itself.
 
 → [Report a River bug](https://github.com/freenet/river/issues/new) ·
 [existing River issues](https://github.com/freenet/river/issues)
 
 ### Freenet itself
 
-Install or uninstall trouble, the node will not start or will not stay running, no connections, high
-CPU or bandwidth use, the menu bar or system tray icon, errors from the `freenet` command. Anything
+Install or uninstall trouble, the node won't start or won't stay running, no connections, high CPU
+or bandwidth use, the menu bar or system tray icon, errors from the `freenet` command. Anything
 underneath the apps rather than inside one.
 
 → [Report a Freenet bug](https://github.com/freenet/freenet-core/issues/new) ·
@@ -42,40 +42,45 @@ underneath the apps rather than inside one.
 
 ### This website
 
-A broken link, documentation that is wrong or confusing, a page that will not load, a typo.
+A broken link, documentation that's wrong or confusing, a page that won't load, a typo.
 
 → [Report a website bug](https://github.com/freenet/web/issues/new) ·
 [existing website issues](https://github.com/freenet/web/issues)
 
 ### Ghost Keys
 
-Anything about donations, Ghost Key certificates, or the vault.
+Anything about donations, Ghost Key certificates, or the Ghostkey Vault.
 
 → [Report a Ghost Keys bug](https://github.com/freenet/ghostkeys/issues/new) ·
 [existing Ghost Keys issues](https://github.com/freenet/ghostkeys/issues)
 
 ### One of the other apps
 
-Delta, Mail, freenet-git, Atlas and the rest each keep their own list. Every app on the
-[apps page](/apps/) links to its own project, and you will find its issues there.
+Each keeps its own list: [Delta](https://github.com/freenet/delta/issues/new),
+[Mail](https://github.com/freenet/mail/issues/new),
+[freenet-git](https://github.com/freenet/freenet-git/issues/new),
+[Raven](https://github.com/freenet/raven/issues/new),
+[Atlas](https://github.com/freenet/atlas/issues/new) and
+[Harvest](https://github.com/freenet/harvest/issues/new). The [apps page](/apps/) says what each one
+does, if you're not sure which you were using.
 
 ### Not sure
 
-Use the [Freenet issue tracker](https://github.com/freenet/freenet-core/issues/new). It is the one
-the maintainers watch most closely, and they will move your report if it belongs somewhere else.
+Use the [Freenet issue tracker](https://github.com/freenet/freenet-core/issues/new). It's the one
+the maintainers watch most closely, and they'll move your report if it belongs somewhere else.
 Describing clearly what happened matters far more than landing it in the right place first time.
 
-If you would rather have someone work it out with you, ask in
+If you'd rather have someone work it out with you, ask in
 [Matrix](https://matrix.to/#/#freenet-locutus:matrix.org).
 
 ## What to put in a bug report
 
-You do not need to diagnose the problem. These are what make a report easy to act on:
+You don't need to diagnose the problem. These are what make a report easy to act on:
 
 - What you were doing, what you expected, and what happened instead.
 - Whether it happens every time or only sometimes.
 - Your operating system, and how you installed Freenet.
-- A screenshot, if it is something you can see.
+- A screenshot, if it's something you can see.
 
 ### The quick way to gather diagnostics
 
@@ -85,23 +90,35 @@ If Freenet is installed on your machine, run this in a terminal:
 freenet service report
 ```
 
-It asks you to describe the problem, gathers your version, operating system, recent log entries and
-configuration, uploads them, and prints a short **report code** that looks like `X7K2M9`. Put that
-code in your bug report and the maintainers can pull up everything they need.
+It gathers your version, operating system, recent log entries and configuration, then asks you to
+describe the problem, uploads everything, and prints a short **report code** that looks like
+`X7K2M9`. Put that code in your bug report and the maintainers can pull up everything they need. The
+step that queries your running node can take up to a minute, so give it a moment before the prompt
+appears.
 
-That upload includes recent log lines and your Freenet configuration file. If you would rather see
-what is in it first, `freenet service report --local report.json` writes it to a file on your own
-machine instead of uploading it.
+That upload is more than logs, so it's worth knowing what's in it: your machine's hostname, recent
+log lines, your Freenet configuration file (which includes paths containing your username), and, if
+your node is running, its current network state. That state covers your peer ID, the addresses of
+the peers you're connected to, and the contracts you're subscribed to, which for River means the
+rooms you're in. Your IP address is recorded when the upload is received.
+
+If you'd rather read all of that before sending it, `freenet service report --local report.json`
+writes the same bundle to a file on your own machine and uploads nothing. There's no way to send a
+saved file afterwards, so run the command again without `--local` once you're happy with it.
+
+If you'd rather not attach the code to a public issue, send it to us in
+[Matrix](https://matrix.to/#/#freenet-locutus:matrix.org) instead and mention your issue number.
 
 ## Prefer to talk to a person?
 
 Our [Matrix room](https://matrix.to/#/#freenet-locutus:matrix.org) is where Freenet's developers and
-users are. It is a good place for "is this even a bug?", for questions the FAQ does not answer, and
-for anything you would rather not write up as a formal report.
+users are. It's a good place for "is this even a bug?", for questions the FAQ doesn't answer, and
+for anything you'd rather not write up as a formal report.
 
 ## Want to help fix things?
 
-A clear bug report is already a real contribution. If you want to go further, every Freenet project
-takes pull requests and each has a `CONTRIBUTING.md` explaining how, starting with
-[freenet-core](https://github.com/freenet/freenet-core/blob/main/CONTRIBUTING.md). The
-[Build section](/build/) covers how Freenet works and how to write apps for it.
+A clear bug report is already a real contribution. If you want to go further,
+[freenet-core's contributing guide](https://github.com/freenet/freenet-core/blob/main/CONTRIBUTING.md)
+explains how the project takes changes. Read it before you write any code: feature work needs an
+agreed issue first, and pull requests that skip that step get closed. The [Build section](/build/)
+covers how Freenet works and how to write apps for it.

--- a/hugo-site/content/community/support/index.md
+++ b/hugo-site/content/community/support/index.md
@@ -49,10 +49,13 @@ A broken link, documentation that's wrong or confusing, a page that won't load, 
 
 ### Ghost Keys
 
-Anything about donations, Ghost Key certificates, or the Ghostkey Vault.
+Trouble with the Ghostkey Vault: importing a key, backing one up, an app that can't get a signature.
 
-→ [Report a Ghost Keys bug](https://github.com/freenet/ghostkeys/issues/new) ·
-[existing Ghost Keys issues](https://github.com/freenet/ghostkeys/issues)
+→ [Report a Ghostkey Vault bug](https://github.com/freenet/ghostkeys/issues/new) ·
+[existing Ghostkey Vault issues](https://github.com/freenet/ghostkeys/issues)
+
+A donation that didn't go through, or a Ghost Key certificate that never arrived, is handled by this
+website rather than by the vault, so [report those here](https://github.com/freenet/web/issues/new).
 
 ### One of the other apps
 
@@ -68,14 +71,14 @@ does, if you're not sure which you were using.
 
 Use the [Freenet issue tracker](https://github.com/freenet/freenet-core/issues/new). It's the one
 the maintainers watch most closely, and they'll move your report if it belongs somewhere else.
-Describing clearly what happened matters far more than landing it in the right place first time.
+Describing clearly what happened matters far more than landing it in the right place the first time.
 
 If you'd rather have someone work it out with you, ask in
 [Matrix](https://matrix.to/#/#freenet-locutus:matrix.org).
 
 ## What to put in a bug report
 
-You don't need to diagnose the problem. These are what make a report easy to act on:
+You don't need to diagnose the problem. What makes a report easy to act on:
 
 - What you were doing, what you expected, and what happened instead.
 - Whether it happens every time or only sometimes.
@@ -92,22 +95,22 @@ freenet service report
 
 It gathers your version, operating system, recent log entries and configuration, then asks you to
 describe the problem, uploads everything, and prints a short **report code** that looks like
-`X7K2M9`. Put that code in your bug report and the maintainers can pull up everything they need. The
-step that queries your running node can take up to a minute, so give it a moment before the prompt
-appears.
+`X7K2M9`. Put that code in your bug report and the maintainers can pull up everything they need. If
+your node isn't answering, that step waits up to a minute before giving up, so the prompt may take a
+while to appear.
 
 That upload is more than logs, so it's worth knowing what's in it: your machine's hostname, recent
 log lines, your Freenet configuration file (which includes paths containing your username), and, if
 your node is running, its current network state. That state covers your peer ID, the addresses of
-the peers you're connected to, and the contracts you're subscribed to, which for River means the
-rooms you're in. Your IP address is recorded when the upload is received.
+the peers you're connected to, and every contract your node holds. For River that includes the rooms
+you're in.
+
+Your IP address is recorded when the upload is received.
 
 If you'd rather read all of that before sending it, `freenet service report --local report.json`
 writes the same bundle to a file on your own machine and uploads nothing. There's no way to send a
-saved file afterwards, so run the command again without `--local` once you're happy with it.
-
-If you'd rather not attach the code to a public issue, send it to us in
-[Matrix](https://matrix.to/#/#freenet-locutus:matrix.org) instead and mention your issue number.
+saved file afterwards, so once you're happy with it, run the command again without `--local` and it
+will collect a fresh copy of the same things.
 
 ## Prefer to talk to a person?
 

--- a/hugo-site/content/donate/thanks/_index.md
+++ b/hugo-site/content/donate/thanks/_index.md
@@ -13,6 +13,6 @@ are tax-deductible in the United States.
 
 ### Stay connected
 
-- Join the conversation on [Matrix](https://matrix.to/#/#freenet:matrix.org)
+- Join the conversation on [Matrix](https://matrix.to/#/#freenet-locutus:matrix.org)
 - Follow project updates on [our news page](/about/news/)
 - Read about the architecture in the [whitepaper](/whitepaper/)

--- a/hugo-site/content/quickstart/_index.md
+++ b/hugo-site/content/quickstart/_index.md
@@ -44,7 +44,7 @@ Prefer the terminal? River has a full-featured CLI, `riverctl`. See the
 ## Troubleshooting
 
 If you run into problems, join our [Matrix chat](https://matrix.to/#/#freenet-locutus:matrix.org)
-for help.
+for help, or see [Report a Bug or Get Help](/community/support/) for where to file a report.
 
 **Invite didn't work?** If River opened but you're not in the room, try restarting Freenet
 (`freenet service restart`), then come back to this page and click the invite button again for a
@@ -67,4 +67,4 @@ Need to remove Freenet? See the [uninstall guide](/uninstall/).
 - [User Manual](/build/manual/) - Learn how Freenet works
 - [Video Talks](/about/video-talks/) - Watch presentations about Freenet
 - [FAQ](/about/faq/) - Common questions and answers
-- [Get Involved](/community/get-involved/) - Contribute to the project
+- [Report a Bug or Get Help](/community/support/) - Where to send a bug report or feature idea

--- a/hugo-site/static/slides/common/call-to-action.html
+++ b/hugo-site/static/slides/common/call-to-action.html
@@ -35,7 +35,7 @@
       <p style="font-size: 0.75em; color: rgba(255,255,255,0.6);">
         <a href="https://freenet.org" style="color: #4facfe; margin: 0 0.8em;">freenet.org</a>
         <a href="https://github.com/freenet" style="color: #4facfe; margin: 0 0.8em;">GitHub</a>
-        <a href="https://matrix.to/#/#freenet:matrix.org" style="color: #4facfe; margin: 0 0.8em;">Matrix</a>
+        <a href="https://matrix.to/#/#freenet-locutus:matrix.org" style="color: #4facfe; margin: 0 0.8em;">Matrix</a>
       </p>
     </div>
   </div>
@@ -45,7 +45,7 @@
       <li>Run a peer: freenet.org/quickstart</li>
       <li>Build: tutorial at freenet.org/resources/manual/tutorial, uses River as example</li>
       <li>AI: dapp-builder skill for Claude</li>
-      <li>Matrix: #freenet:matrix.org</li>
+      <li>Matrix: #freenet-locutus:matrix.org</li>
     </ul>
   </aside>
 </section>

--- a/hugo-site/static/slides/common/questions.html
+++ b/hugo-site/static/slides/common/questions.html
@@ -12,7 +12,7 @@
     </p>
     <p style="margin: 0.8em 0;">
       <span style="color: #43e97b;">💬</span>
-      <a href="https://matrix.to/#/#freenet:matrix.org" style="color: rgba(255,255,255,0.8); margin-left: 0.5em;">Matrix: #freenet:matrix.org</a>
+      <a href="https://matrix.to/#/#freenet-locutus:matrix.org" style="color: rgba(255,255,255,0.8); margin-left: 0.5em;">Matrix: #freenet-locutus:matrix.org</a>
     </p>
     <p style="margin: 0.8em 0;">
       <span style="color: #a855f7;">𝕏</span>

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -1107,6 +1107,43 @@ picture.app-screenshot img {
   }
 }
 
+/* Bug-report route in the footer — the one support link present on every page,
+   so it has to read as a link rather than as a caption. */
+.footer-report {
+  text-align: center;
+  margin: 2rem auto 0;
+  padding: 0 1rem;
+  font-size: 0.9rem;
+}
+
+.footer-report p {
+  margin: 0;
+}
+
+.footer-report a {
+  color: #64748b;
+  text-decoration: underline;
+  text-decoration-color: rgba(100, 116, 139, 0.4);
+  text-underline-offset: 2px;
+}
+
+.footer-report a:hover {
+  color: var(--color-primary);
+  text-decoration-color: var(--color-primary);
+}
+
+@media (prefers-color-scheme: dark) {
+  .footer-report a {
+    color: #94a3b8;
+    text-decoration-color: rgba(148, 163, 184, 0.4);
+  }
+
+  .footer-report a:hover {
+    color: #4da6ff;
+    text-decoration-color: #4da6ff;
+  }
+}
+
 /* Institutional statement in footer — quiet, just establishes 501(c)(3) status */
 .footer-institutional {
   max-width: 720px;

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -1108,7 +1108,8 @@ picture.app-screenshot img {
 }
 
 /* Bug-report route in the footer — the one support link present on every page,
-   so it has to read as a link rather than as a caption. */
+   so it has to read as a link rather than as a caption. Shares the quiet
+   underlined link treatment with .footer-institutional below. */
 .footer-report {
   text-align: center;
   margin: 2rem auto 0;
@@ -1118,30 +1119,6 @@ picture.app-screenshot img {
 
 .footer-report p {
   margin: 0;
-}
-
-.footer-report a {
-  color: #64748b;
-  text-decoration: underline;
-  text-decoration-color: rgba(100, 116, 139, 0.4);
-  text-underline-offset: 2px;
-}
-
-.footer-report a:hover {
-  color: var(--color-primary);
-  text-decoration-color: var(--color-primary);
-}
-
-@media (prefers-color-scheme: dark) {
-  .footer-report a {
-    color: #94a3b8;
-    text-decoration-color: rgba(148, 163, 184, 0.4);
-  }
-
-  .footer-report a:hover {
-    color: #4da6ff;
-    text-decoration-color: #4da6ff;
-  }
 }
 
 /* Institutional statement in footer — quiet, just establishes 501(c)(3) status */
@@ -1159,29 +1136,34 @@ picture.app-screenshot img {
   margin: 0;
 }
 
-.footer-institutional a {
+.footer-institutional a,
+.footer-report a {
   color: #64748b;
   text-decoration: underline;
   text-decoration-color: rgba(100, 116, 139, 0.4);
   text-underline-offset: 2px;
 }
 
-.footer-institutional a:hover {
+.footer-institutional a:hover,
+.footer-report a:hover {
   color: var(--color-primary);
   text-decoration-color: var(--color-primary);
 }
 
 @media (prefers-color-scheme: dark) {
   .footer-institutional,
-  .footer-institutional a {
+  .footer-institutional a,
+  .footer-report a {
     color: #94a3b8;
   }
 
-  .footer-institutional a {
+  .footer-institutional a,
+  .footer-report a {
     text-decoration-color: rgba(148, 163, 184, 0.4);
   }
 
-  .footer-institutional a:hover {
+  .footer-institutional a:hover,
+  .footer-report a:hover {
     color: #4da6ff;
     text-decoration-color: #4da6ff;
   }

--- a/hugo-site/themes/freenet/layouts/partials/footer.html
+++ b/hugo-site/themes/freenet/layouts/partials/footer.html
@@ -1,3 +1,6 @@
+<div class="footer-report">
+    <p><a href="/community/support/">Report a bug or get help</a></p>
+</div>
 <div class="footer-institutional">
     <p>
         Founded in 2001, Freenet is a 501(c)(3) nonprofit organization dedicated to the development


### PR DESCRIPTION
## Problem

An ordinary user on freenet.org who hits a bug has nowhere correct to go.
Concretely, on the live site today:

- The strings "report a bug", "file an issue" and "bug report" appear
  nowhere in the site's content or templates.
- The only GitHub link in the footer is the "src: freenet/web" credit, so
  the single most obvious place a user would click routes every River bug
  and every node bug into the *website's* tracker.
- /community/support/ and /community/get-involved/ are published but
  completely empty (title front matter, no body). Quickstart's "What's
  Next" list links to the latter, so the one navigational promise of a
  community route is a blank page.
- Nothing anywhere states which repo covers what. /apps/ links ten repos,
  but as project homepages, not as "report bugs here".

Freenet spans freenet-core, river, web, ghostkeys and the rest, so "file
an issue" is ambiguous even for someone willing to look.

## Approach

Fill the existing empty /community/support/ page with a routing page that
sorts a reporter by what they were doing, rather than adding new
scaffolding. It covers River, the node itself, the website, Ghost Keys,
other apps, and an explicit "Not sure" route (freenet-core, which the
maintainers watch most and can move a report from).

It says plainly that filing on GitHub needs a GitHub account, and offers
Matrix as the route for people who do not want one. It also documents
`freenet service report`, which produces a report code maintainers can
look up, along with `--local` for anyone who would rather inspect the
bundle before uploading it.

Discovery: one footer link, present on every page, plus an entry in the
homepage's secondary-links row and in Quickstart's Troubleshooting and
"What's Next" sections, which is where a struggling user already is.

The empty get-involved stub is deleted; /community/get-involved/ and a
new short /report/ both alias to the page, so the Quickstart link that
previously dead-ended now lands somewhere real.

## Testing

- `hugo` builds clean; `scripts/check-links.py` reports no broken
  internal links across 223 pages.
- Alias redirects verified in the built output for /report/ and
  /community/get-involved/.
- All five external GitHub targets return 200.
- Rendered and screenshotted at 1200px and 390px, light and dark
  palettes covered by the CSS.

[AI-assisted - Claude]