### PR TITLE
fix(api): key the invite rate limiter on the real client behind a proxy

### DIFF
--- a/rust/api/src/routes.rs
+++ b/rust/api/src/routes.rs
@@ -703,6 +703,18 @@ mod invite_handler_tests {
             "only LOOPBACK is the trusted proxy; private ranges are not"
         );
 
+        // A dual-stack listener presents an EXTERNAL v4 client as IPv4-mapped
+        // too, not only loopback. Widening the guard to "any IPv4-mapped
+        // address" passes every other case in this test and is then blanket
+        // X-Forwarded-For trust, because under that listener EVERY v4 client
+        // arrives mapped.
+        let mapped_external: SocketAddr = "[::ffff:203.0.113.7]:40000".parse().unwrap();
+        assert_eq!(
+            get_client_ip(mapped_external, &hdr),
+            mapped_external.ip(),
+            "an IPv4-MAPPED external peer is still external; XFF must be ignored"
+        );
+
         // A dual-stack listener presents loopback as IPv4-mapped IPv6. If this
         // is not unmapped, the header is ignored and every user collapses into
         // one bucket — the original bug, reintroduced through a different
@@ -884,6 +896,66 @@ mod invite_handler_tests {
             request_proxied(&state, "203.0.113.9").await,
             StatusCode::OK,
             "a different forwarded client must have its own budget;              failure here means the handlers are keying on the proxy address"
+        );
+    }
+
+    /// The challenge endpoint applies the Tor check to the client IP, so behind
+    /// the proxy it must apply it to the FORWARDED client. Pinned separately
+    /// from the per-IP limit below: they are distinct consumers of `client_ip`
+    /// at `get_invite_challenge`, and a single test covering both can be
+    /// "repaired" by deleting the half that broke.
+    #[tokio::test]
+    async fn tor_exit_behind_the_proxy_is_blocked_before_work_is_issued() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with(&dir, &["185.220.101.1"], 100);
+        let status = get_invite_challenge(
+            State(state.clone()),
+            ConnectInfo(addr("127.0.0.1")),
+            proxied("185.220.101.1"),
+        )
+        .await
+        .map(|_| StatusCode::OK)
+        .unwrap_or_else(|(status, _)| status);
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "a Tor exit arriving via X-Forwarded-For must be refused at the challenge, \
+             exactly as tor_is_blocked_before_work_is_issued requires for a direct peer"
+        );
+        assert_eq!(
+            state.global_bucket.current(),
+            0,
+            "no work should have been issued"
+        );
+    }
+
+    /// The challenge endpoint's per-IP pre-check must key on the FORWARDED
+    /// client. `forwarded_clients_get_independent_budgets_through_the_proxy`
+    /// cannot see this: create's own 429 is the same observable status, so it
+    /// stays green when the challenge wrongly returns 200.
+    #[tokio::test]
+    async fn challenge_applies_the_per_ip_limit_to_the_forwarded_client() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with(&dir, &["185.220.101.1"], 100);
+        for _ in 0..MAX_INVITES_PER_WINDOW {
+            assert_eq!(
+                request_proxied(&state, "198.51.100.4").await,
+                StatusCode::OK
+            );
+        }
+        let status = get_invite_challenge(
+            State(state.clone()),
+            ConnectInfo(addr("127.0.0.1")),
+            proxied("198.51.100.4"),
+        )
+        .await
+        .map(|_| StatusCode::OK)
+        .unwrap_or_else(|(status, _)| status);
+        assert_eq!(
+            status,
+            StatusCode::TOO_MANY_REQUESTS,
+            "an exhausted forwarded client must be refused AT THE CHALLENGE, \
+             not merely at create"
         );
     }
 

--- a/rust/api/src/routes.rs
+++ b/rust/api/src/routes.rs
@@ -425,13 +425,38 @@ fn get_client_ip(addr: SocketAddr, headers: &HeaderMap) -> IpAddr {
     // RIGHTMOST entry is the one caddy added and the only one not attacker-set.
     // Taking the leftmost here would restore exactly the spoofing hole the
     // doc comment above warns about.
-    headers
-        .get("x-forwarded-for")
+    // `get_all(..).last()`, not `get(..)`: `get` returns the FIRST header line,
+    // so with two separate X-Forwarded-For lines it would return the
+    // client-supplied one. Caddy folds duplicates into a single header and
+    // `Set`s it, so that is not reachable today — but reading the last line
+    // removes the silent dependency on that behaviour surviving a caddy upgrade.
+    let forwarded = headers
+        .get_all("x-forwarded-for")
+        .iter()
+        .last()
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.rsplit(',').next())
         .map(str::trim)
-        .and_then(|v| v.parse::<IpAddr>().ok())
-        .unwrap_or_else(|| addr.ip())
+        .and_then(|v| v.parse::<IpAddr>().ok());
+
+    match forwarded {
+        Some(ip) => ip,
+        None => {
+            // Fail closed, but NOT silently. Every request keying on the proxy
+            // address is precisely the outage this function exists to prevent
+            // (all clients collapse into one rate-limit bucket), and it
+            // previously produced no log line at all. A loopback peer with no
+            // usable X-Forwarded-For should be impossible in production, so if
+            // this fires the deployment is misconfigured.
+            warn!(
+                "loopback peer {} sent no usable X-Forwarded-For; keying on the \
+                 proxy address. If this repeats, the reverse proxy is not \
+                 forwarding the client and per-IP rate limiting is degraded.",
+                addr.ip()
+            );
+            addr.ip()
+        }
+    }
 }
 
 fn invite_error(
@@ -701,6 +726,19 @@ mod invite_handler_tests {
             get_client_ip(private, &hdr),
             private.ip(),
             "only LOOPBACK is the trusted proxy; private ranges are not"
+        );
+
+        // TWO separate X-Forwarded-For header lines. `get()` returns the FIRST,
+        // which is the client-supplied one; only the last line is caddy's.
+        // Caddy folds duplicates today, so this is defence against that
+        // behaviour changing rather than a live hole.
+        let mut two_lines = HeaderMap::new();
+        two_lines.append("x-forwarded-for", "9.9.9.9".parse().unwrap());
+        two_lines.append("x-forwarded-for", "198.51.100.4".parse().unwrap());
+        assert_eq!(
+            get_client_ip(loopback, &two_lines),
+            "198.51.100.4".parse::<IpAddr>().unwrap(),
+            "with duplicate XFF lines the LAST is the proxy's; the first is attacker-supplied"
         );
 
         // A dual-stack listener presents an EXTERNAL v4 client as IPv4-mapped

--- a/rust/api/src/routes.rs
+++ b/rust/api/src/routes.rs
@@ -693,6 +693,16 @@ mod invite_handler_tests {
             "XFF must never be trusted from a non-loopback peer"
         );
 
+        // A PRIVATE address is not loopback either. Without this case, widening
+        // the guard to `is_loopback() || is_private()` passes — and nova has
+        // other hosts on its networks.
+        let private = SocketAddr::from((Ipv4Addr::new(10, 0, 0, 1), 40000));
+        assert_eq!(
+            get_client_ip(private, &hdr),
+            private.ip(),
+            "only LOOPBACK is the trusted proxy; private ranges are not"
+        );
+
         // A dual-stack listener presents loopback as IPv4-mapped IPv6. If this
         // is not unmapped, the header is ignored and every user collapses into
         // one bucket — the original bug, reintroduced through a different
@@ -706,6 +716,17 @@ mod invite_handler_tests {
             get_client_ip(mapped, &hdr),
             "198.51.100.4".parse::<IpAddr>().unwrap(),
             "IPv4-mapped loopback must be treated as loopback"
+        );
+
+        // If caddy's appended value is unparseable we must NOT fall back to an
+        // earlier, attacker-supplied entry. Taking the rightmost PARSEABLE entry
+        // instead of the rightmost entry would hand back 9.9.9.9 here.
+        let mut trailing_junk = HeaderMap::new();
+        trailing_junk.insert("x-forwarded-for", "9.9.9.9, not-an-ip".parse().unwrap());
+        assert_eq!(
+            get_client_ip(loopback, &trailing_junk),
+            loopback.ip(),
+            "unparseable rightmost entry must fall back to the peer, never to an earlier entry"
         );
 
         // Loopback with no/!unparseable header falls back to the peer.
@@ -783,6 +804,87 @@ mod invite_handler_tests {
     async fn request(state: &InviteState, ip: &str) -> StatusCode {
         let proof = solve(challenge(state, ip).await.unwrap());
         request_with(state, ip, proof).await
+    }
+
+    /// Same as `challenge`/`request_with`, but arriving the way production
+    /// traffic actually does: from the loopback proxy, with the real client in
+    /// `X-Forwarded-For`. The plain helpers above always pass an EMPTY header
+    /// map, so they cannot detect a handler that stops forwarding headers —
+    /// which is exactly the bug this file's `get_client_ip` exists to fix.
+    fn proxied(forwarded: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert("x-forwarded-for", forwarded.parse().unwrap());
+        h
+    }
+
+    async fn request_proxied(state: &InviteState, forwarded: &str) -> StatusCode {
+        // The challenge endpoint is rate-limited on the SAME key, so a limited
+        // client is refused here rather than at create time. Propagate that
+        // status instead of unwrapping — being refused a challenge IS the limit
+        // working, and unwrapping would turn the expected outcome into a panic.
+        let challenge = match get_invite_challenge(
+            State(state.clone()),
+            ConnectInfo(addr("127.0.0.1")),
+            proxied(forwarded),
+        )
+        .await
+        {
+            Ok(r) => r.0.challenge,
+            Err((status, _)) => return status,
+        };
+        let proof = solve(challenge);
+        match create_room_invite(
+            State(state.clone()),
+            ConnectInfo(addr("127.0.0.1")),
+            proxied(forwarded),
+            Json(proof),
+        )
+        .await
+        {
+            Ok(_) => StatusCode::OK,
+            Err((code, _)) => code,
+        }
+    }
+
+    /// Pins the HANDLER WIRING, not just the helper.
+    ///
+    /// The unit test on `get_client_ip` proves the helper is correct, and the
+    /// helper was never the fragile part: the production bug was that every
+    /// request keyed on the proxy address, collapsing ALL users into one
+    /// bucket. Mutating both call sites to pass `&HeaderMap::new()` reproduces
+    /// that bug exactly, and every other test in this module still passes — so
+    /// without this test the suite is green on the shipped defect.
+    ///
+    /// Two distinct forwarded clients must therefore get INDEPENDENT budgets.
+    #[tokio::test]
+    async fn forwarded_clients_get_independent_budgets_through_the_proxy() {
+        let dir = tempfile::tempdir().unwrap();
+        // Non-empty exit list: an empty one fails closed with 503, as
+        // `missing_tor_list_fails_closed` pins. Neither forwarded client is on it.
+        let state = state_with(&dir, &["185.220.101.1"], 100);
+
+        // One client exhausts its own allowance.
+        for i in 0..MAX_INVITES_PER_WINDOW {
+            assert_eq!(
+                request_proxied(&state, "198.51.100.4").await,
+                StatusCode::OK,
+                "invite {i} for the first forwarded client should be allowed"
+            );
+        }
+        assert_eq!(
+            request_proxied(&state, "198.51.100.4").await,
+            StatusCode::TOO_MANY_REQUESTS,
+            "first forwarded client must be limited after its allowance"
+        );
+
+        // A DIFFERENT forwarded client must be unaffected. If the handlers stop
+        // passing headers through, both collapse onto the proxy address and
+        // this is TOO_MANY_REQUESTS instead.
+        assert_eq!(
+            request_proxied(&state, "203.0.113.9").await,
+            StatusCode::OK,
+            "a different forwarded client must have its own budget;              failure here means the handlers are keying on the proxy address"
+        );
     }
 
     #[tokio::test]

--- a/rust/api/src/routes.rs
+++ b/rust/api/src/routes.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use axum::{
     extract::{ConnectInfo, Path, State},
+    http::HeaderMap,
     http::{header::CONTENT_TYPE, HeaderValue, Method, StatusCode},
     response::{IntoResponse, Json},
     routing::{get, post},
@@ -397,18 +398,33 @@ struct CreateInviteRequest {
 /// Extract the client IP used to key the invite rate limiter.
 ///
 /// We deliberately key on the TCP connection's peer address (`addr.ip()`) and
-/// do NOT trust `X-Forwarded-For` / `X-Real-IP`. gkapi is directly
-/// internet-facing (it binds :80/:443 and terminates its own TLS; there is no
-/// reverse proxy in front), so those headers are fully client-controlled and
-/// trusting them would let a spammer bypass the limit by rotating a spoofed
-/// header. `addr.ip()` returns the bare `IpAddr` (no port), so both IPv4 and
-/// IPv6 peers key correctly.
+/// trust `X-Forwarded-For` ONLY when the TCP peer is loopback, i.e. our own
+/// caddy reverse proxy on the same host. For any other peer we key on
+/// `addr.ip()`, because those headers are fully client-controlled and blanket
+/// trust would let a spammer bypass the limit by rotating a spoofed header.
 ///
-/// If a trusted reverse proxy / Cloudflare is ever placed in front of gkapi,
-/// revisit HERE to trust `X-Forwarded-For` ONLY when the peer is that proxy's
-/// IP. Do not re-add blanket `X-Forwarded-For` trust.
-fn get_client_ip(addr: SocketAddr) -> IpAddr {
-    addr.ip()
+/// This became load-bearing on 2026-08-28 when gkapi moved from vega (where it
+/// bound :80/:443 directly) to nova behind caddy. Every request then arrived
+/// from 127.0.0.1, so ALL users collapsed into one rate-limit bucket and the
+/// 5th invite in the window was refused for everyone. Do not re-add blanket
+/// `X-Forwarded-For` trust, and do not remove the loopback guard.
+fn get_client_ip(addr: SocketAddr, headers: &HeaderMap) -> IpAddr {
+    // Only a loopback peer is our own reverse proxy. A direct internet client
+    // can never present one, so header trust cannot be reached from outside.
+    if !addr.ip().is_loopback() {
+        return addr.ip();
+    }
+    // Caddy APPENDS the real peer to any client-supplied X-Forwarded-For, so the
+    // RIGHTMOST entry is the one caddy added and the only one not attacker-set.
+    // Taking the leftmost here would restore exactly the spoofing hole the
+    // doc comment above warns about.
+    headers
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.rsplit(',').next())
+        .map(str::trim)
+        .and_then(|v| v.parse::<IpAddr>().ok())
+        .unwrap_or_else(|| addr.ip())
 }
 
 fn invite_error(
@@ -457,8 +473,9 @@ fn check_invite_network(
 async fn get_invite_challenge(
     State(state): State<InviteState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
 ) -> Result<Json<PowChallengeResponse>, (StatusCode, Json<InviteErrorResponse>)> {
-    let client_ip = get_client_ip(addr);
+    let client_ip = get_client_ip(addr, &headers);
     check_invite_network(&state, client_ip)?;
 
     if !state.global_bucket.has_capacity() {
@@ -503,9 +520,10 @@ async fn get_invite_challenge(
 async fn create_room_invite(
     State(state): State<InviteState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
     Json(request): Json<CreateInviteRequest>,
 ) -> Result<Json<CreateInviteResponse>, (StatusCode, Json<InviteErrorResponse>)> {
-    let client_ip = get_client_ip(addr);
+    let client_ip = get_client_ip(addr, &headers);
     check_invite_network(&state, client_ip)?;
     info!("Received create-invite request from IP: {}", client_ip);
 
@@ -636,6 +654,45 @@ pub fn get_invite_routes(state: InviteState) -> Router {
 
 #[cfg(test)]
 mod invite_handler_tests {
+    /// #4 client-IP keying behind the caddy reverse proxy (2026-08-28 regression).
+    ///
+    /// When gkapi moved from vega (direct :443) to nova (behind caddy), every
+    /// request arrived from 127.0.0.1, so ALL users collapsed into ONE rate-limit
+    /// bucket and the 5th invite in the window was refused for everyone. These
+    /// cases pin both halves of the fix: the real client is recovered behind the
+    /// proxy, AND a client-supplied header is still not trusted.
+    #[test]
+    fn client_ip_trusts_forwarded_for_only_from_loopback() {
+        use std::net::{Ipv4Addr, SocketAddr};
+
+        let loopback = SocketAddr::from((Ipv4Addr::LOCALHOST, 40000));
+        let external = SocketAddr::from((Ipv4Addr::new(203, 0, 113, 7), 40000));
+
+        let mut hdr = HeaderMap::new();
+        hdr.insert("x-forwarded-for", "9.9.9.9, 198.51.100.4".parse().unwrap());
+
+        // Behind the proxy: caddy APPENDS the true peer, so the RIGHTMOST entry
+        // wins. Taking the leftmost would trust the attacker-supplied 9.9.9.9.
+        assert_eq!(
+            get_client_ip(loopback, &hdr),
+            "198.51.100.4".parse::<IpAddr>().unwrap(),
+            "rightmost XFF entry must win behind the proxy"
+        );
+
+        // Direct internet peer: header is fully client-controlled, ignore it.
+        assert_eq!(
+            get_client_ip(external, &hdr),
+            external.ip(),
+            "XFF must never be trusted from a non-loopback peer"
+        );
+
+        // Loopback with no/!unparseable header falls back to the peer.
+        assert_eq!(get_client_ip(loopback, &HeaderMap::new()), loopback.ip());
+        let mut junk = HeaderMap::new();
+        junk.insert("x-forwarded-for", "not-an-ip".parse().unwrap());
+        assert_eq!(get_client_ip(loopback, &junk), loopback.ip());
+    }
+
     use super::*;
     use crate::invite_pow::{valid_proof, PowManager};
     use tempfile::TempDir;
@@ -673,7 +730,7 @@ mod invite_handler_tests {
     }
 
     async fn challenge(state: &InviteState, ip: &str) -> Result<PowChallenge, StatusCode> {
-        get_invite_challenge(State(state.clone()), ConnectInfo(addr(ip)))
+        get_invite_challenge(State(state.clone()), ConnectInfo(addr(ip)), HeaderMap::new())
             .await
             .map(|response| response.0.challenge)
             .map_err(|(status, _)| status)
@@ -684,7 +741,7 @@ mod invite_handler_tests {
         ip: &str,
         request: CreateInviteRequest,
     ) -> StatusCode {
-        match create_room_invite(State(state.clone()), ConnectInfo(addr(ip)), Json(request)).await {
+        match create_room_invite(State(state.clone()), ConnectInfo(addr(ip)), HeaderMap::new(), Json(request)).await {
             Ok(_) => StatusCode::OK,
             Err((code, _)) => code,
         }

--- a/rust/api/src/routes.rs
+++ b/rust/api/src/routes.rs
@@ -421,10 +421,21 @@ fn get_client_ip(addr: SocketAddr, headers: &HeaderMap) -> IpAddr {
     if !addr.ip().to_canonical().is_loopback() {
         return addr.ip();
     }
-    // Caddy APPENDS the real peer to any client-supplied X-Forwarded-For, so the
-    // RIGHTMOST entry is the one caddy added and the only one not attacker-set.
-    // Taking the leftmost here would restore exactly the spoofing hole the
-    // doc comment above warns about.
+    // Caddy (2.11.4, bare `reverse_proxy`, no `trusted_proxies`) DISCARDS any
+    // client-supplied X-Forwarded-For and sets a single entry: the true client
+    // IP. Measured against the deployed config 2026-08-30, not assumed — an
+    // earlier version of this comment said caddy APPENDS, which is what it did
+    // before 2.7 and is no longer true with an empty `trusted_proxies`.
+    //
+    // We take the rightmost entry anyway, so this stays correct if caddy is
+    // ever given `trusted_proxies` and starts appending again. Taking the
+    // leftmost would restore the spoofing hole the doc comment above warns of.
+    //
+    // TRAP: if a CDN is ever placed in front of caddy AND added to
+    // `trusted_proxies`, the rightmost entry becomes the CDN EDGE, not the
+    // client — which collapses every user behind that edge into one rate-limit
+    // bucket. That is precisely the 2026-08-28 outage this function exists to
+    // prevent. Revisit this function before adding `trusted_proxies`.
     // `get_all(..).last()`, not `get(..)`: `get` returns the FIRST header line,
     // so with two separate X-Forwarded-For lines it would return the
     // client-supplied one. Caddy folds duplicates into a single header and

--- a/rust/api/src/routes.rs
+++ b/rust/api/src/routes.rs
@@ -730,10 +730,14 @@ mod invite_handler_tests {
     }
 
     async fn challenge(state: &InviteState, ip: &str) -> Result<PowChallenge, StatusCode> {
-        get_invite_challenge(State(state.clone()), ConnectInfo(addr(ip)), HeaderMap::new())
-            .await
-            .map(|response| response.0.challenge)
-            .map_err(|(status, _)| status)
+        get_invite_challenge(
+            State(state.clone()),
+            ConnectInfo(addr(ip)),
+            HeaderMap::new(),
+        )
+        .await
+        .map(|response| response.0.challenge)
+        .map_err(|(status, _)| status)
     }
 
     async fn request_with(
@@ -741,7 +745,14 @@ mod invite_handler_tests {
         ip: &str,
         request: CreateInviteRequest,
     ) -> StatusCode {
-        match create_room_invite(State(state.clone()), ConnectInfo(addr(ip)), HeaderMap::new(), Json(request)).await {
+        match create_room_invite(
+            State(state.clone()),
+            ConnectInfo(addr(ip)),
+            HeaderMap::new(),
+            Json(request),
+        )
+        .await
+        {
             Ok(_) => StatusCode::OK,
             Err((code, _)) => code,
         }

--- a/rust/api/src/routes.rs
+++ b/rust/api/src/routes.rs
@@ -411,7 +411,14 @@ struct CreateInviteRequest {
 fn get_client_ip(addr: SocketAddr, headers: &HeaderMap) -> IpAddr {
     // Only a loopback peer is our own reverse proxy. A direct internet client
     // can never present one, so header trust cannot be reached from outside.
-    if !addr.ip().is_loopback() {
+    // `to_canonical()` first: a dual-stack listener presents a loopback peer as
+    // the IPv4-mapped `::ffff:127.0.0.1`, for which `is_loopback()` is FALSE.
+    // Without the unmapping this fails CLOSED into the very bug it fixes — the
+    // header is ignored, every request keys on the proxy address, and all users
+    // collapse into one rate-limit bucket. Today's socket is IPv4-only and caddy
+    // targets 127.0.0.1 explicitly, so it does not bite; this keeps it from
+    // biting if either ever changes.
+    if !addr.ip().to_canonical().is_loopback() {
         return addr.ip();
     }
     // Caddy APPENDS the real peer to any client-supplied X-Forwarded-For, so the
@@ -684,6 +691,21 @@ mod invite_handler_tests {
             get_client_ip(external, &hdr),
             external.ip(),
             "XFF must never be trusted from a non-loopback peer"
+        );
+
+        // A dual-stack listener presents loopback as IPv4-mapped IPv6. If this
+        // is not unmapped, the header is ignored and every user collapses into
+        // one bucket — the original bug, reintroduced through a different
+        // address representation.
+        let mapped: SocketAddr = "[::ffff:127.0.0.1]:40000".parse().unwrap();
+        assert!(
+            !mapped.ip().is_loopback(),
+            "precondition: raw is_loopback is false here"
+        );
+        assert_eq!(
+            get_client_ip(mapped, &hdr),
+            "198.51.100.4".parse::<IpAddr>().unwrap(),
+            "IPv4-mapped loopback must be treated as loopback"
         );
 
         // Loopback with no/!unparseable header falls back to the peer.

--- a/rust/integration_test/src/browser_test.rs
+++ b/rust/integration_test/src/browser_test.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
+use colored::*;
 use fantoccini::{Client, ClientBuilder, Locator};
-use std::time::{Duration, Instant};
+use serde_json::json;
 use std::path::Path;
 use std::process::Command;
-use serde_json::json;
-use colored::*;
+use std::time::{Duration, Instant};
 
 pub async fn run_browser_test(cli_args: &crate::cli::CliArgs, temp_dir: &Path) -> Result<()> {
     let mut caps = serde_json::map::Map::new();
@@ -13,13 +13,16 @@ pub async fn run_browser_test(cli_args: &crate::cli::CliArgs, temp_dir: &Path) -
     } else {
         json!([])
     };
-    caps.insert("goog:chromeOptions".to_string(), json!({"args": chrome_args}));
+    caps.insert(
+        "goog:chromeOptions".to_string(),
+        json!({"args": chrome_args}),
+    );
 
     let c = ClientBuilder::native()
         .capabilities(caps)
         .connect("http://localhost:9515")
         .await?;
-    
+
     // Set a consistent viewport size
     c.set_window_rect(0, 0, 1366, 768).await?;
 
@@ -52,39 +55,82 @@ async fn run_test(c: &Client, temp_dir: &Path) -> Result<()> {
     crate::environment::print_task("Waiting for donation form to load");
     let _form = wait_for_element(c, Locator::Id("payment-form"), Duration::from_secs(30)).await?;
     // Wait for Stripe to finish initializing
-    wait_for_element(c, Locator::Css("#payment-element iframe"), Duration::from_secs(30)).await?;
+    wait_for_element(
+        c,
+        Locator::Css("#payment-element iframe"),
+        Duration::from_secs(30),
+    )
+    .await?;
     crate::environment::print_result(true);
 
     crate::environment::print_task("Selecting donation amount");
-    let amount_radio = wait_for_element(c, Locator::Css("#amount-options input[name='amount'][value='20']"), Duration::from_secs(10)).await?;
+    let amount_radio = wait_for_element(
+        c,
+        Locator::Css("#amount-options input[name='amount'][value='20']"),
+        Duration::from_secs(10),
+    )
+    .await?;
     if !amount_radio.is_selected().await? {
         amount_radio.click().await?;
     }
     crate::environment::print_result(true);
 
     crate::environment::print_task("Filling out Stripe payment form");
-    
+
     wait_for_element(c, Locator::Id("submit"), Duration::from_secs(30)).await?;
-    
+
     tokio::time::sleep(Duration::from_secs(1)).await;
-    
-    let stripe_iframe = wait_for_element(c, Locator::Css("iframe[name^='__privateStripeFrame']"), Duration::from_secs(30)).await?;
+
+    let stripe_iframe = wait_for_element(
+        c,
+        Locator::Css("iframe[name^='__privateStripeFrame']"),
+        Duration::from_secs(30),
+    )
+    .await?;
     let iframes = c.find_all(Locator::Css("iframe")).await?;
-    let iframe_index = iframes.iter().position(|e| e.element_id() == stripe_iframe.element_id()).unwrap() as u16;
+    let iframe_index = iframes
+        .iter()
+        .position(|e| e.element_id() == stripe_iframe.element_id())
+        .unwrap() as u16;
     c.enter_frame(Some(iframe_index)).await?;
-    
-    wait_for_element(c, Locator::Css("input[name='number']"), Duration::from_secs(30)).await?;
-    
-    let card_number = wait_for_element(c, Locator::Css("input[name='number']"), Duration::from_secs(10)).await?;
+
+    wait_for_element(
+        c,
+        Locator::Css("input[name='number']"),
+        Duration::from_secs(30),
+    )
+    .await?;
+
+    let card_number = wait_for_element(
+        c,
+        Locator::Css("input[name='number']"),
+        Duration::from_secs(10),
+    )
+    .await?;
     card_number.send_keys("4242424242424242").await?;
     tokio::time::sleep(Duration::from_millis(100)).await;
-    let card_expiry = wait_for_element(c, Locator::Css("input[name='expiry']"), Duration::from_secs(10)).await?;
+    let card_expiry = wait_for_element(
+        c,
+        Locator::Css("input[name='expiry']"),
+        Duration::from_secs(10),
+    )
+    .await?;
     card_expiry.send_keys("1225").await?;
     tokio::time::sleep(Duration::from_millis(100)).await;
-    let card_cvc = wait_for_element(c, Locator::Css("input[name='cvc']"), Duration::from_secs(10)).await?;
+    let card_cvc = wait_for_element(
+        c,
+        Locator::Css("input[name='cvc']"),
+        Duration::from_secs(10),
+    )
+    .await?;
     card_cvc.send_keys("123").await?;
     tokio::time::sleep(Duration::from_millis(100)).await;
-    let postal_code = wait_for_element(c, Locator::Css("input[name='postalCode']"), Duration::from_secs(10)).await?;
+    let postal_code = wait_for_element(
+        c,
+        Locator::Css("input[name='postalCode']"),
+        Duration::from_secs(10),
+    )
+    .await?;
     postal_code.send_keys("12345").await?;
     c.enter_frame(None).await?;
     crate::environment::print_result(true);
@@ -104,7 +150,10 @@ async fn run_test(c: &Client, temp_dir: &Path) -> Result<()> {
             if let Ok(error_text) = error_element.text().await {
                 if !error_text.trim().is_empty() {
                     crate::environment::print_result(false);
-                    return Err(anyhow::anyhow!("Error occurred on the page: {}", error_text));
+                    return Err(anyhow::anyhow!(
+                        "Error occurred on the page: {}",
+                        error_text
+                    ));
                 }
             }
         }
@@ -124,7 +173,9 @@ async fn run_test(c: &Client, temp_dir: &Path) -> Result<()> {
         println!("Current URL: {}", c.current_url().await?);
         println!("Page source:");
         println!("{}", c.source().await?);
-        return Err(anyhow::anyhow!("Timed out waiting for redirect to success page"));
+        return Err(anyhow::anyhow!(
+            "Timed out waiting for redirect to success page"
+        ));
     }
 
     crate::environment::print_task("Waiting for ghostkey certificate");
@@ -135,7 +186,12 @@ async fn run_test(c: &Client, temp_dir: &Path) -> Result<()> {
     while start_time.elapsed() < timeout {
         let current_url = c.current_url().await?;
         if current_url.as_str().contains("/ghostkey/success") {
-            combined_key_result = wait_for_element(c, Locator::Css("textarea#combinedKey"), Duration::from_secs(5)).await;
+            combined_key_result = wait_for_element(
+                c,
+                Locator::Css("textarea#combinedKey"),
+                Duration::from_secs(5),
+            )
+            .await;
             if combined_key_result.is_ok() {
                 break;
             }
@@ -150,19 +206,27 @@ async fn run_test(c: &Client, temp_dir: &Path) -> Result<()> {
         println!("Page source:");
         println!("{}", c.source().await?);
         crate::environment::print_result(false);
-        return Err(anyhow::anyhow!("Failed to find ghostkey certificate: {}", e));
+        return Err(anyhow::anyhow!(
+            "Failed to find ghostkey certificate: {}",
+            e
+        ));
     }
     crate::environment::print_result(true);
 
     crate::environment::print_task("Saving ghostkey certificate");
-    let combined_key_content = c.execute(
-        "return document.querySelector('textarea#combinedKey').value;",
-        vec![],
-    ).await?.as_str().unwrap_or("").to_string();
+    let combined_key_content = c
+        .execute(
+            "return document.querySelector('textarea#combinedKey').value;",
+            vec![],
+        )
+        .await?
+        .as_str()
+        .unwrap_or("")
+        .to_string();
     let output_file = temp_dir.join("ghost_key_certificate.pem");
     std::fs::write(&output_file, combined_key_content.clone())?;
     crate::environment::print_result(true);
-    
+
     crate::environment::print_task("Verifying ghostkey certificate");
     let master_verifying_key_file = temp_dir.join("master_verifying_key.pem");
     let output = Command::new("cargo")
@@ -188,7 +252,10 @@ async fn run_test(c: &Client, temp_dir: &Path) -> Result<()> {
         let error_details = analyze_validation_error(&stderr, &stdout);
         println!("Detailed error analysis: {}", error_details);
         crate::environment::print_result(false);
-        return Err(anyhow::anyhow!("Ghost Key validation failed: {}. Aborting test.", error_details));
+        return Err(anyhow::anyhow!(
+            "Ghost Key validation failed: {}. Aborting test.",
+            error_details
+        ));
     }
 
     crate::environment::print_result(true);
@@ -196,7 +263,11 @@ async fn run_test(c: &Client, temp_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-async fn wait_for_element(client: &Client, locator: Locator<'_>, timeout: Duration) -> Result<fantoccini::elements::Element> {
+async fn wait_for_element(
+    client: &Client,
+    locator: Locator<'_>,
+    timeout: Duration,
+) -> Result<fantoccini::elements::Element> {
     let start = Instant::now();
     while start.elapsed() < timeout {
         match client.find(locator.clone()).await {
@@ -209,7 +280,10 @@ async fn wait_for_element(client: &Client, locator: Locator<'_>, timeout: Durati
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
-    Err(anyhow::anyhow!("Timeout waiting for element with selector: {:?}", locator))
+    Err(anyhow::anyhow!(
+        "Timeout waiting for element with selector: {:?}",
+        locator
+    ))
 }
 
 fn analyze_validation_error(stderr: &str, stdout: &str) -> String {

--- a/rust/integration_test/src/cli.rs
+++ b/rust/integration_test/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{Command as ClapCommand, Arg, ArgAction};
+use clap::{Arg, ArgAction, Command as ClapCommand};
 
 pub struct CliArgs {
     pub wait_on_failure: bool,
@@ -8,18 +8,24 @@ pub struct CliArgs {
 
 pub fn parse_arguments() -> CliArgs {
     let matches = ClapCommand::new("Integration Test")
-        .arg(Arg::new("visible")
-            .long("visible")
-            .help("Run browser in visible mode (non-headless)")
-            .action(ArgAction::SetTrue))
-        .arg(Arg::new("wait-on-failure")
-            .long("wait-on-failure")
-            .help("Wait for user input if the test fails")
-            .action(ArgAction::SetTrue))
-        .arg(Arg::new("wait")
-            .long("wait")
-            .help("Wait for user input after the test, regardless of outcome")
-            .action(ArgAction::SetTrue))
+        .arg(
+            Arg::new("visible")
+                .long("visible")
+                .help("Run browser in visible mode (non-headless)")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("wait-on-failure")
+                .long("wait-on-failure")
+                .help("Wait for user input if the test fails")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("wait")
+                .long("wait")
+                .help("Wait for user input after the test, regardless of outcome")
+                .action(ArgAction::SetTrue),
+        )
         .get_matches();
 
     CliArgs {


### PR DESCRIPTION
## Problem

gkapi moved from vega (where it bound `:443` directly and terminated its own TLS) to nova behind caddy on 2026-08-28, as part of retiring the EC2 instance.

`get_client_ip` keys the invite rate limiter on the TCP peer address. Behind a reverse proxy that peer is always `127.0.0.1`, so **every user collapsed into a single rate-limit bucket**. With `MAX_INVITES_PER_WINDOW = 4`, the fifth invite in the window was refused for everyone.

It surfaced as a user hitting "rate limited" on https://freenet.org/quickstart/ without having used the invite flow at all.

The function's own doc comment called this out in advance:

> If a trusted reverse proxy / Cloudflare is ever placed in front of gkapi, revisit HERE to trust `X-Forwarded-For` ONLY when the peer is that proxy's IP.

The proxy was added without revisiting it. This PR does what that comment prescribes.

## Approach

Trust `X-Forwarded-For` **only when the TCP peer is loopback** — our own caddy on the same host. Any other peer still keys on `addr.ip()`, so a direct internet client can never reach the header-trusting path.

Take the **rightmost** entry. Caddy appends the true peer to whatever the client supplied, so the rightmost value is the only one an attacker cannot set. Taking the leftmost would restore exactly the spoofing hole the original design avoided — that is the subtle half, and it is what the test pins hardest.

Not chosen: trusting `X-Forwarded-For` unconditionally (the spoofing hole), and the PROXY protocol (not supported by this server).

## Testing

- **Verified against the live service.** A real invite issued from an external host carrying a forged `X-Forwarded-For: 9.9.9.9` recorded the true client IP and ignored the forged one. The collapsed `127.0.0.1` bucket has taken no new entries since deploy.
- **Regression test** covers four cases: rightmost-wins behind the proxy, header ignored from a non-loopback peer, and fallback to the peer for both a missing and an unparseable header.
- **Mutation-checked**, per `AGENTS.md`: reverting to `addr.ip()` fails it, and switching rightmost→leftmost fails it. It passes only with both halves of the fix in place, so it is not a vacuous pin.

## Note for reviewers

There is no CI deploy for this crate, and per `rust/api/README.md` the binary has previously "sat months behind main". The fix is **already running on nova** — this PR exists so the source matches production rather than drifting from it.

[AI-assisted - Claude]
