### PR TITLE
chore(keys): move the vega gateway to port 31338

### DIFF
--- a/hugo-site/static/keys/gateways.toml
+++ b/hugo-site/static/keys/gateways.toml
@@ -5,9 +5,17 @@ public_key = "keys/public.nova.gw.pem"
 [gateways.address]
 hostname = "nova.locut.us:31337"
 
-# Vega gateway (AWS) - Secondary gateway
+# Vega gateway - Secondary gateway.
+#
+# Moved off AWS to nova on 2026-08-29 to cut ~$198/mo. It now runs as a second
+# process on the same host as the nova gateway, so it needs a distinct PORT:
+# both hostnames resolve to 5.9.111.215 and only one process can own 31337.
+#
+# The public key is UNCHANGED. The transport keypair was carried across, and the
+# private key was verified to derive exactly this published key, so no peer sees
+# a new gateway identity.
 [[gateways]]
 public_key = "keys/public.vega.gw.pem"
 
 [gateways.address]
-hostname = "vega.locut.us:31337"
+hostname = "vega.locut.us:31338"


### PR DESCRIPTION
## Problem

The vega gateway is moving off AWS to nova, to cut roughly **$198/mo** (~$2,370/yr). The largest line on that bill is data egress at $78.94/mo — precisely what a gateway does, and unmetered on nova.

It now runs as a **second freenet process on the same host** as the nova gateway. Both `nova.locut.us` and `vega.locut.us` will resolve to `5.9.111.215`, and only one process can bind UDP 31337, so the second needs a distinct port.

## Approach

Change the vega entry's port to `31338`. The **public key is unchanged**: vega's transport keypair was carried over to nova, and the private key was verified to derive exactly the published `c28123df…d46856`. No peer sees a new gateway identity — only a new port.

The gateway is already running on nova at `5.9.111.215:31338` with its own `--data-dir`, `--config-dir` and `--ws-api-port`, so it does not share the node identity or WS port with the first gateway.

## Rollout

Peers re-fetch this file at every startup. A peer holding a stale copy will dial `vega.locut.us:31337`, reach **nova's first gateway**, and fail the handshake on the public-key mismatch until it re-fetches. That is bounded and self-correcting, and the `nova.locut.us` entry keeps working throughout, so no peer loses the ability to bootstrap.

**Ordering matters:** this must land *and be deployed* before `vega.locut.us` is repointed at nova. Until then the record still points at AWS and nothing changes for peers.

## Testing

Config-only change; `gateways.toml` is served statically from `hugo-site/static/keys/`. The receiving side is exercised by the running gateway: it is live on nova at `:31338`, has formed peer connections, and its data and config directories are confirmed separate from the first gateway's.

Note on ring position: both gateways compute the same ring `Location`, because `Location::from_address` masks the IPv4 /24 and ignores the port. This was checked against freenet-core and is not a problem — a joiner's position derives from its *own* address, bootstrap dials all configured gateways in parallel rather than by distance, and gateways are not special-cased in routing or hosting.

[AI-assisted - Claude]
