### PR TITLE
chore: remove locut.us domain from dashboard links

### DIFF
--- a/hugo-site/content/quickstart/_index.md
+++ b/hugo-site/content/quickstart/_index.md
@@ -63,7 +63,7 @@ Need to remove Freenet? See the [uninstall guide](/uninstall/).
 
 ## What's Next?
 
-- [Live Network Dashboard](http://nova.locut.us:3133/) - Watch real-time activity on the network
+- [Live Network Dashboard](https://telemetry.freenet.org/) - Watch real-time activity on the network
 - [User Manual](/build/manual/) - Learn how Freenet works
 - [Video Talks](/about/video-talks/) - Watch presentations about Freenet
 - [FAQ](/about/faq/) - Common questions and answers

--- a/hugo-site/static/slides/demo/dashboard-live.html
+++ b/hugo-site/static/slides/demo/dashboard-live.html
@@ -1,7 +1,7 @@
-<section data-background-iframe="http://nova.locut.us:3133" data-background-interactive>
+<section data-background-iframe="https://telemetry.freenet.org" data-background-interactive>
   <div style="position: absolute; bottom: 20px; left: 20px; background: rgba(0,0,0,0.7); padding: 10px 20px; border-radius: 8px;">
     <h3 style="margin: 0; font-size: 1em;">Live Network Dashboard</h3>
-    <p style="margin: 0.3em 0 0 0; font-size: 0.7em; color: #aaa;">nova.locut.us:3133</p>
+    <p style="margin: 0.3em 0 0 0; font-size: 0.7em; color: #aaa;">telemetry.freenet.org</p>
   </div>
 
   <aside class="notes">

--- a/hugo-site/static/slides/demo/dashboard.html
+++ b/hugo-site/static/slides/demo/dashboard.html
@@ -7,7 +7,7 @@
     </div>
 
     <p style="margin-top: 0.8em; font-size: 0.9em; color: rgba(255,255,255,0.7);">
-      Live: <a href="http://nova.locut.us:3133" target="_blank" style="color: #4facfe;">nova.locut.us:3133</a>
+      Live: <a href="https://telemetry.freenet.org" target="_blank" style="color: #4facfe;">telemetry.freenet.org</a>
       <span style="margin-left: 1.5em; font-size: 0.85em;">
         <a href="/slides/demo/telemetry-dashboard.webm" target="_blank" style="color: rgba(255,255,255,0.5);">[backup video]</a>
       </span>


### PR DESCRIPTION
## Problem
`nova.locut.us` is registered to Ian's home address and appears in public-facing pages (quickstart guide, slide-deck demo pages).

## Approach
The old `http://nova.locut.us:3133/` dashboard URL already 301-redirects to the canonical `https://telemetry.freenet.org/`, so this swaps all three references to use the canonical domain directly instead of the personal one.

## Testing
- Verified `curl -sI http://nova.locut.us:3133/` returns a 301 to `https://telemetry.freenet.org/`.
- Verified `https://telemetry.freenet.org/` resolves and returns 200.
- Not otherwise built/tested (content-only Hugo edits).

## Not touched
`hugo-site/static/keys/gateways.toml` still references `nova.locut.us` and `vega.locut.us` — that file is being handled separately in #123 and was explicitly out of scope here.

[AI-assisted - Claude]