### PR TITLE
docs: stop calling the browser version a centralized demo

### DIFF
--- a/hugo-site/content/_index.md
+++ b/hugo-site/content/_index.md
@@ -22,9 +22,10 @@ in the middle.
   <a href="/try/" class="cta-secondary-btn">Open River in your&nbsp;browser&nbsp;→</a>
 </div>
 
-<p class="cta-note">The browser version is a centralized demo running on our server. Installing your
-own peer takes a couple of minutes on Windows, macOS or Linux, and gives you the real thing, with no
-server in the middle.</p>
+<p class="cta-note">The browser version is the real River on the real Freenet network. You're just
+borrowing a peer we run instead of one on your own machine, so your keys live with us. Installing
+your own peer takes a couple of minutes on Windows, macOS or Linux, and keeps everything on your
+side.</p>
 
 </div>
 

--- a/hugo-site/content/quickstart/_index.md
+++ b/hugo-site/content/quickstart/_index.md
@@ -10,9 +10,9 @@ It's the best way to see the network for real.
 The room runs as a Freenet contract: code that lives across the peer-to-peer network instead of on
 a central server. No company hosts it, no account to make, no admin who can shut it down.
 
-Want to look before installing? [Try River in your browser](/try/), a hosted demo of this same
-room with no download. It runs on a peer we host instead of one on your machine, so it's a
-preview rather than the real thing.
+Want to look before installing? [Try River in your browser](/try/), the same room on the same
+network with no download. It runs on a peer we host instead of one on your machine, so your keys
+live with us until you install.
 
 {{< alert type="warning" >}} **Alpha notes:** Freenet is under active development.
 
@@ -56,7 +56,7 @@ system-wide service instead: `sudo freenet service install --system`
 
 **Network requirements:** Freenet uses UDP hole punching for peer-to-peer connections. Most home
 routers support this without configuration. Strict corporate firewalls may block connections. If
-yours does, the [hosted demo](/try/) usually still works, since it reaches the network over HTTPS
+yours does, the [browser version](/try/) usually still works, since it reaches the network over HTTPS
 through a peer we host.
 
 Need to remove Freenet? See the [uninstall guide](/uninstall/).

--- a/hugo-site/content/try/_index.md
+++ b/hugo-site/content/try/_index.md
@@ -8,16 +8,19 @@ Try Freenet right now, no install. This opens **River**, a group chat app that r
 peer-to-peer Freenet contract, and drops you into the live **Freenet Official** room where the
 project's developers and users talk. No account, no download.
 
-{{< alert type="warning" >}} **This is a hosted demo.** It runs on our server, so your data lives
-with us. It's encrypted with your access key, so while you're not using it even we can't read it.
-[Install your own peer](/quickstart/) anytime and export your data to it in one click. {{< /alert >}}
+{{< alert type="warning" >}} **You're using our peer, not your own.** Everything else here is the
+real thing: the real River app, the real Freenet network, the same room people running their own
+peers are in. The one difference is that the peer talking to the network is one we host, so your
+keys live with us. They're encrypted with your access key, so while you're not using it even we
+can't read them. [Install your own peer](/quickstart/) anytime and export your data to it in one
+click. {{< /alert >}}
 
 {{< river-invite-button room="Freenet Official" base="https://try.freenet.org/v1/contract/web/raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv/" hosted="true" >}}
 
-## Ready for the real thing?
+## Ready to run your own peer?
 
-The hosted demo is centralized, which is the opposite of what Freenet is for. Running your own peer
-takes a couple of minutes and gives you the real deal: apps that can't be taken down, don't track
-you, and run without any server.
+What you do here really happens on Freenet, so the only piece you're borrowing is the peer itself.
+Running your own takes a couple of minutes and closes that gap: your keys stay on your machine, and
+your computer joins the network instead of leaning on ours.
 
 [Install Freenet →](/quickstart/)

--- a/hugo-site/themes/freenet/assets/css/freenet.css
+++ b/hugo-site/themes/freenet/assets/css/freenet.css
@@ -246,8 +246,9 @@
     text-decoration: none;
 }
 
-/* Caveat under the CTA row: the browser option is a hosted demo. Quiet, but
-   present, so the homepage never implies the demo is decentralized. */
+/* Caveat under the CTA row: the browser option runs on a peer we host, so the
+   visitor's keys live with us. Quiet, but present, so the homepage never
+   implies the browser option is as self-sufficient as your own peer. */
 .cta-note {
     margin: -2.25rem 0 3.25rem 0;
     max-width: 34rem;

--- a/hugo-site/themes/freenet/layouts/shortcodes/river-invite-button.html
+++ b/hugo-site/themes/freenet/layouts/shortcodes/river-invite-button.html
@@ -141,7 +141,7 @@
         </details>
 
         {{ if eq (.Get "hosted") "true" }}
-        <p class="note">This is a hosted demo running on our server, no install needed. River may take a moment to load the first time.</p>
+        <p class="note">This runs on a Freenet peer we host, so there's nothing to install. River may take a moment to load the first time.</p>
         {{ else }}
         <p class="note">Make sure Freenet is running. Please be patient, River may take a while to load when your peer first starts.</p>
         {{ end }}


### PR DESCRIPTION
## Problem

The site told visitors the browser version of River was a **centralized demo**:

> The browser version is a centralized demo running on our server.

and, on `/try/`:

> This is a hosted demo. It runs on our server…
> The hosted demo is centralized, which is the opposite of what Freenet is for.

That is misleading. `try.freenet.org` is a real Freenet peer we run, fronted by
`freenet-gateway-proxy`. A visitor there loads the real River web contract
(`raAqMhMG7KUpXBU2SxgCQ3Vh4PYjttxdSWd9ftV7RLv`) and joins the same **Freenet Official**
room that people running their own peers are in. Messages go over the real network. Nothing
about the app or the network is a mock-up, so "centralized demo" told visitors their session
was a simulation of Freenet rather than Freenet itself.

## Approach

Say the accurate, narrower thing: you are **using our peer instead of your own**, so your keys
live on our peer rather than your machine — and that is the reason to install.

Existing claims that are still true were left alone: the access-key encryption line on `/try/`,
the one-click export to your own peer, and the firewall-fallback note in the quickstart.

Files changed (copy only, no logic):

- `content/_index.md` — home hero note under the CTA row
- `content/try/_index.md` — the warning callout and the closing section ("Ready for the real thing?" → "Ready to run your own peer?")
- `content/quickstart/_index.md` — "look before installing" intro, and "hosted demo" → "browser version" in the firewall note
- `themes/freenet/layouts/shortcodes/river-invite-button.html` — the `hosted="true"` variant's note

## Testing

`hugo --minify` builds clean; new copy verified in the rendered `public/index.html` and
`public/try/index.html`. No logic touched.

[AI-assisted - Claude]
