### PR TITLE
chore: group Dependabot updates and slow the cadence to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,124 @@
+version: 2
+
+# Dependabot configuration.
+#
+# Shaped by GitHub's "Tame Dependabot: group your updates, slow the cadence,
+# keep security fast" guidance:
+# https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/
+#
+#   - GROUP routine churn, so a month of bumps arrives as ONE reviewable PR per
+#     ecosystem instead of thirty. Open PRs are not free: they rot into
+#     conflicts, and a wall of them trains reviewers to skim past the whole
+#     list, including the bumps that matter.
+#   - SLOW the cadence to monthly, so updates land on a rhythm you can plan
+#     around rather than "whenever anything upstream changes".
+#   - COOLDOWN of 7 days, so a release has been in the wild long enough for a
+#     bad one to be found and yanked before it is proposed here. Dependabot
+#     already applies 3 days by default; this raises it. Note the interaction
+#     with a monthly schedule: a release published just inside the window is
+#     skipped and waits for the NEXT monthly run, so the practical delay from
+#     publish to PR can approach five weeks, not seven days.
+#
+# ONE PLACE THIS DELIBERATELY DEPARTS FROM THE ARTICLE.
+#
+# The article says to delete `open-pull-requests-limit`. Do not. Omitting the
+# key does not mean "unlimited" -- the documented default is FIVE, and once five
+# version-update PRs are open Dependabot raises no more until some are closed.
+# That is silent withholding, the exact failure the article is arguing against,
+# so the limit is set EXPLICITLY and set high enough never to bind in practice.
+# Grouping, not the limit, is what controls the noise. (Security PRs are exempt
+# from the limit and do not count toward it.)
+#
+# TWO THINGS THIS DELIBERATELY DOES NOT DO. Both are one config key away, and
+# both would be worse than the noise this file exists to reduce:
+#
+# 1. It does not group MAJOR bumps. Every group below matches only `minor` and
+#    `patch`, so a major arrives as its own PR with its own review. A major can
+#    change behaviour, and must never land buried in a large diff that reads as
+#    routine.
+#
+#    Know how Dependabot classifies, because it differs by ecosystem. For CARGO
+#    it applies Cargo's own semver rules, where for a 0.y.z crate a bump in y is
+#    BREAKING: `0.8 -> 0.9` is treated as a MAJOR, falls out of the group, and
+#    arrives as its own PR. That is right for Rust, and it is why the cargo
+#    limit below is generous -- a repo with many 0.x dependencies produces a
+#    real queue of individual PRs alongside the single grouped one. For every
+#    other ecosystem here (npm, pip, docker, gradle, github-actions) Dependabot
+#    compares raw version segments instead, so an npm `0.8 -> 0.9` is classified
+#    `minor` and WILL be grouped, even though npm convention treats 0.x minors
+#    as breaking. The "majors are always reviewed alone" guarantee is therefore
+#    strong for cargo and weaker for the rest.
+#
+# 2. It does not touch SECURITY updates. `applies-to` defaults to
+#    `version-updates`, so Dependabot's security PRs ignore the grouping, the
+#    monthly schedule, the cooldown and the PR limit entirely, and keep arriving
+#    one per advisory, immediately. Do NOT "finish the job" by adding
+#    `applies-to: security-updates` -- slowing security fixes down is precisely
+#    the outcome this configuration avoids.
+
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/rust"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    # Set explicitly: omitting this caps at 5 and silently withholds the rest.
+    open-pull-requests-limit: 50
+    groups:
+      cargo-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # excluded from the /rust workspace, so updated on its own
+  - package-ecosystem: "cargo"
+    directory: "/rust/gklib"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    # Set explicitly: omitting this caps at 5 and silently withholds the rest.
+    open-pull-requests-limit: 50
+    groups:
+      cargo-rust-gklib-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # excluded from the /rust workspace, so updated on its own
+  - package-ecosystem: "cargo"
+    directory: "/rust/cli"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    # Set explicitly: omitting this caps at 5 and silently withholds the rest.
+    open-pull-requests-limit: 50
+    groups:
+      cargo-rust-cli-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    # Set explicitly: omitting this caps at 5 and silently withholds the rest.
+    open-pull-requests-limit: 20
+    groups:
+      github-actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Applies GitHub's "Tame Dependabot" guidance: group routine version bumps
into one PR per ecosystem, move the schedule to monthly, and add a 7-day
cooldown so a release has time to be found bad and yanked before it is
proposed here.

One deliberate departure from the article, which says to delete
`open-pull-requests-limit`. Omitting that key does not mean unlimited --
the default is 5, and once five version-update PRs are open Dependabot
raises no more. That is the silent withholding the article argues against,
so the limit is instead set explicitly and set high (50 for cargo, 20
elsewhere), high enough not to bind. Grouping is what controls the noise.

Cargo needs the extra headroom because Dependabot applies Cargo's semver
rules, where a 0.y.z crate's y-bump is breaking: `0.8 -> 0.9` counts as a
major, falls out of the group, and arrives as its own PR.

Security updates are untouched. `applies-to` defaults to `version-updates`,
so security PRs ignore the grouping, schedule, cooldown and limit, and keep
arriving one per advisory, immediately.

Major bumps are also left ungrouped: every group matches only `minor` and
`patch`, so a major still gets its own PR and its own review.

Ref: https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/

[AI-assisted - Claude]

