### PR TITLE
docs: correct install time and reword the hosted-peer caveat

### DIFF
--- a/hugo-site/content/_index.md
+++ b/hugo-site/content/_index.md
@@ -24,8 +24,8 @@ in the middle.
 
 <p class="cta-note">The browser version is the real River on the real Freenet network. You're just
 borrowing a peer we run instead of one on your own machine, so your keys live with us. Installing
-your own peer takes a couple of minutes on Windows, macOS or Linux, and keeps everything on your
-side.</p>
+your own peer takes a few seconds on Windows, macOS or Linux, keeps your data on your hardware, and
+your private data moves across from our peer in a single click.</p>
 
 </div>
 

--- a/hugo-site/content/try/_index.md
+++ b/hugo-site/content/try/_index.md
@@ -20,7 +20,8 @@ click. {{< /alert >}}
 ## Ready to run your own peer?
 
 What you do here really happens on Freenet, so the only piece you're borrowing is the peer itself.
-Running your own takes a couple of minutes and closes that gap: your keys stay on your machine, and
-your computer joins the network instead of leaning on ours.
+Running your own takes a few seconds and closes that gap: your keys stay on your hardware, and your
+computer joins the network instead of leaning on ours. Your private data moves across from our peer
+in a single click.
 
 [Install Freenet →](/quickstart/)


### PR DESCRIPTION
## Problem

Ian's feedback on the current hosted-peer copy:

1. Both the homepage note and `/try` claimed installing your own peer "takes a couple of minutes". It takes a few seconds. We were overstating the cost of the exact action we want visitors to take.
2. The homepage note ended on "keeps everything on your side", which is vague about what "everything" is and where "your side" is.
3. Neither the homepage note nor the "Ready to run your own peer?" section mentioned that private data on our peer migrates across in a single click. `/try` said it only inside the warning alert, so at the two points where a visitor weighs whether switching costs them their history, the migration path was invisible.

## Approach

Copy edit to `hugo-site/content/_index.md` and `hugo-site/content/try/_index.md`:

- "a couple of minutes" becomes "a few seconds" in both places.
- "keeps everything on your side" becomes "keeps your data on your hardware", which names the concrete thing.
- Both sections now say the private data moves across from our peer in a single click.

No layout, CSS, or shortcode changes.

## Testing

`hugo` builds clean and the rendered `public/index.html` and `public/try/index.html` carry the new text.

[AI-assisted - Claude]

https://claude.ai/code/session_01W49hU1RFJB25AQ5X4hvyt5
