### PR TITLE
feat(bug): move bug reporting to /bug/ and list every project's tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ rust/browser-extension/wasm
 
 # Python bytecode from scripts/
 __pycache__/
+hugo-site/public_review

--- a/hugo-site/content/_index.md
+++ b/hugo-site/content/_index.md
@@ -133,6 +133,6 @@ just a few hops, scaling efficiently to millions of peers, no servers required.
 [River](/river/) · [Apps](/apps/) · [Video Talks](/about/video-talks/) ·
 [Matrix Chat](https://matrix.to/#/#freenet-locutus:matrix.org) ·
 [GitHub](https://github.com/freenet/freenet-core) · [FAQ](/about/faq/) ·
-[Report a Bug](/community/support/)
+[Report a Bug](/bug/)
 
 </div>

--- a/hugo-site/content/bug/index.md
+++ b/hugo-site/content/bug/index.md
@@ -22,13 +22,19 @@ report for you.
 
 Filing a report on GitHub needs a free GitHub account. If you'd rather not create one, say it in
 [our Matrix room](https://matrix.to/#/#freenet-locutus:matrix.org) instead and someone will file it
-for you.
+for you. The one exception is a security vulnerability, which should never go in a public room. See
+below.
 
-{{< alert type="warning" >}} **Found a security vulnerability?** Don't open a public issue. A public
-write-up of an unfixed hole tells everyone how to attack the network before there's a fix. Report it
-privately instead, through
-[Freenet's security advisory form](https://github.com/freenet/freenet-core/security/advisories/new),
-whichever project it affects. We'll credit you when the fix ships. {{< /alert >}}
+{{< alert type="warning" >}} **Found a security vulnerability?** Don't open a public issue, and
+don't describe it in the Matrix room either. A public write-up of an unfixed hole tells everyone how
+to attack the network before there's a fix.
+
+Use
+[the freenet-core advisory form](https://github.com/freenet/freenet-core/security/advisories/new)
+even when the bug is in River, Delta or any other project. It is the one private channel, and the
+other repositories have no equivalent form. It needs a GitHub account; without one, email
+{{< email-protect "gro.teneerf@nai" "ian@freenet.org" >}} instead. We'll acknowledge your report and
+work with you on a fix and a coordinated disclosure. {{< /alert >}}
 
 ## What were you using?
 
@@ -88,34 +94,35 @@ If you'd rather have someone work it out with you, ask in
 
 ## Every project's tracker {#every-project}
 
-The complete list, largest project first. Most people only ever need the first three. Each name
-opens a blank report form for that project. To read what has already been filed, click **Issues** at
-the top of the form.
+The complete list, most-starred project first. Most people only ever need the first three. Each name
+opens that project's open issues, so you can check whether yours is already there; the **New issue**
+button is at the top of that page.
 
-| Project                                                                                          | What it covers                         |
-| ------------------------------------------------------------------------------------------------ | -------------------------------------- |
-| [freenet-core](https://github.com/freenet/freenet-core/issues/new)                               | The Freenet peer itself                |
-| [river](https://github.com/freenet/river/issues/new)                                             | River group chat and `riverctl`        |
-| [web](https://github.com/freenet/web/issues/new)                                                 | This website, freenet.org              |
-| [freenet-git](https://github.com/freenet/freenet-git/issues/new)                                 | Git hosting over Freenet               |
-| [delta](https://github.com/freenet/delta/issues/new)                                             | Decentralized website builder          |
-| [mail](https://github.com/freenet/mail/issues/new)                                               | Decentralized email                    |
-| [atlas](https://github.com/freenet/atlas/issues/new)                                             | Discovery layer, at the RFC stage      |
-| [raven](https://github.com/freenet/raven/issues/new)                                             | Live social feed                       |
-| [freenet-agent-skills](https://github.com/freenet/freenet-agent-skills/issues/new)               | Skills for AI coding agents            |
-| [freenet-stdlib](https://github.com/freenet/freenet-stdlib/issues/new)                           | Contract and delegate library          |
-| [harvest](https://github.com/freenet/harvest/issues/new)                                         | Peer-to-peer marketplace               |
-| [freenet-wiki](https://github.com/freenet/freenet-wiki/issues/new)                               | Decentralized wiki                     |
-| [replay-channel](https://github.com/freenet/replay-channel/issues/new)                           | Rust broadcast-channel library         |
-| [freenet-scaffold](https://github.com/freenet/freenet-scaffold/issues/new)                       | Mergeable contract state crate         |
-| [freenet-telemetry-dashboard](https://github.com/freenet/freenet-telemetry-dashboard/issues/new) | The dashboard at telemetry.freenet.org |
-| [ghostkeys](https://github.com/freenet/ghostkeys/issues/new)                                     | Ghost Keys vault and delegate          |
-| [freenet-migrate](https://github.com/freenet/freenet-migrate/issues/new)                         | App data across version changes        |
-| [freenet-delegates](https://github.com/freenet/freenet-delegates/issues/new)                     | Shared utility delegates               |
+| Project                                                                                      | What it covers                         |
+| -------------------------------------------------------------------------------------------- | -------------------------------------- |
+| [freenet-core](https://github.com/freenet/freenet-core/issues)                               | The Freenet peer itself                |
+| [river](https://github.com/freenet/river/issues)                                             | River group chat and `riverctl`        |
+| [web](https://github.com/freenet/web/issues)                                                 | This website, freenet.org              |
+| [freenet-git](https://github.com/freenet/freenet-git/issues)                                 | Git hosting over Freenet               |
+| [delta](https://github.com/freenet/delta/issues)                                             | Decentralized website builder          |
+| [mail](https://github.com/freenet/mail/issues)                                               | Decentralized email                    |
+| [atlas](https://github.com/freenet/atlas/issues)                                             | Discovery layer, at the RFC stage      |
+| [raven](https://github.com/freenet/raven/issues)                                             | Live social feed                       |
+| [freenet-agent-skills](https://github.com/freenet/freenet-agent-skills/issues)               | Skills for AI coding agents            |
+| [freenet-stdlib](https://github.com/freenet/freenet-stdlib/issues)                           | Contract and delegate library          |
+| [harvest](https://github.com/freenet/harvest/issues)                                         | Peer-to-peer marketplace               |
+| [freenet-wiki](https://github.com/freenet/freenet-wiki/issues)                               | Decentralized wiki                     |
+| [replay-channel](https://github.com/freenet/replay-channel/issues)                           | Rust broadcast-channel library         |
+| [freenet-scaffold](https://github.com/freenet/freenet-scaffold/issues)                       | Mergeable contract state crate         |
+| [paper-1](https://github.com/freenet/paper-1/issues)                                         | Source of the architectural whitepaper |
+| [freenet-telemetry-dashboard](https://github.com/freenet/freenet-telemetry-dashboard/issues) | The dashboard at telemetry.freenet.org |
+| [ghostkeys](https://github.com/freenet/ghostkeys/issues)                                     | Ghost Keys vault and delegate          |
+| [freenet-migrate](https://github.com/freenet/freenet-migrate/issues)                         | App data across version changes        |
+| [freenet-delegates](https://github.com/freenet/freenet-delegates/issues)                     | Shared utility delegates               |
 
-Repositories not listed here are internal build and test infrastructure. If a bug seems to belong to
-one of those, file it against [freenet-core](https://github.com/freenet/freenet-core/issues/new) and
-it will get moved.
+Anything not listed is internal infrastructure, a dormant experiment, or a crate with issues
+switched off. If a bug seems to belong to one of those, file it against
+[freenet-core](https://github.com/freenet/freenet-core/issues/new) and it will get moved.
 
 ## What to put in a bug report
 

--- a/hugo-site/content/bug/index.md
+++ b/hugo-site/content/bug/index.md
@@ -8,6 +8,7 @@ draft: false
 aliases:
   - /bugs/
   - /report/
+  - /community/
   - /community/support/
   - /community/get-involved/
 ---

--- a/hugo-site/content/bug/index.md
+++ b/hugo-site/content/bug/index.md
@@ -31,10 +31,10 @@ to attack the network before there's a fix.
 
 Use
 [the freenet-core advisory form](https://github.com/freenet/freenet-core/security/advisories/new)
-even when the bug is in River, Delta or any other project. It is the one private channel, and the
-other repositories have no equivalent form. It needs a GitHub account; without one, email
-{{< email-protect "gro.teneerf@nai" "ian@freenet.org" >}} instead. We'll acknowledge your report and
-work with you on a fix and a coordinated disclosure. {{< /alert >}}
+even when the bug is in River, Delta or any other project. Reports for every project are handled
+there. It needs a GitHub account; without one, email Ian at **ian at freenet dot org**, spelled that
+way to slow down address scrapers. We'll acknowledge your report and work with you on a fix and a
+coordinated disclosure. {{< /alert >}}
 
 ## What were you using?
 
@@ -94,9 +94,9 @@ If you'd rather have someone work it out with you, ask in
 
 ## Every project's tracker {#every-project}
 
-The complete list, most-starred project first. Most people only ever need the first three. Each name
-opens that project's open issues, so you can check whether yours is already there; the **New issue**
-button is at the top of that page.
+Every project you can file against, most-starred first. Most people only ever need the first three.
+Each name opens that project's open issues, so you can check whether yours is already there; the
+**New issue** button is at the top of that page.
 
 | Project                                                                                      | What it covers                         |
 | -------------------------------------------------------------------------------------------- | -------------------------------------- |
@@ -120,8 +120,8 @@ button is at the top of that page.
 | [freenet-migrate](https://github.com/freenet/freenet-migrate/issues)                         | App data across version changes        |
 | [freenet-delegates](https://github.com/freenet/freenet-delegates/issues)                     | Shared utility delegates               |
 
-Anything not listed is internal infrastructure, a dormant experiment, or a crate with issues
-switched off. If a bug seems to belong to one of those, file it against
+Anything not listed is internal infrastructure, dormant, or has issues switched off. If a bug seems
+to belong to one of those, file it against
 [freenet-core](https://github.com/freenet/freenet-core/issues/new) and it will get moved.
 
 ## What to put in a bug report

--- a/hugo-site/content/bug/index.md
+++ b/hugo-site/content/bug/index.md
@@ -6,7 +6,9 @@ description:
 date: 2026-08-25
 draft: false
 aliases:
+  - /bugs/
   - /report/
+  - /community/support/
   - /community/get-involved/
 ---
 
@@ -20,6 +22,12 @@ report for you.
 Filing a report on GitHub needs a free GitHub account. If you'd rather not create one, say it in
 [our Matrix room](https://matrix.to/#/#freenet-locutus:matrix.org) instead and someone will file it
 for you.
+
+{{< alert type="warning" >}} **Found a security vulnerability?** Don't open a public issue. A public
+write-up of an unfixed hole tells everyone how to attack the network before there's a fix. Report it
+privately instead, through
+[Freenet's security advisory form](https://github.com/freenet/freenet-core/security/advisories/new),
+whichever project it affects. We'll credit you when the fix ships. {{< /alert >}}
 
 ## What were you using?
 
@@ -65,7 +73,8 @@ Each keeps its own list: [Delta](https://github.com/freenet/delta/issues/new),
 [Raven](https://github.com/freenet/raven/issues/new),
 [Atlas](https://github.com/freenet/atlas/issues/new) and
 [Harvest](https://github.com/freenet/harvest/issues/new). The [apps page](/apps/) says what each one
-does, if you're not sure which you were using.
+does, if you're not sure which you were using, and [every tracker](#every-project) is listed further
+down this page.
 
 ### Not sure
 
@@ -75,6 +84,37 @@ Describing clearly what happened matters far more than landing it in the right p
 
 If you'd rather have someone work it out with you, ask in
 [Matrix](https://matrix.to/#/#freenet-locutus:matrix.org).
+
+## Every project's tracker {#every-project}
+
+The complete list, largest project first. Most people only ever need the first three. Each name
+opens a blank report form for that project. To read what has already been filed, click **Issues** at
+the top of the form.
+
+| Project                                                                                          | What it covers                         |
+| ------------------------------------------------------------------------------------------------ | -------------------------------------- |
+| [freenet-core](https://github.com/freenet/freenet-core/issues/new)                               | The Freenet peer itself                |
+| [river](https://github.com/freenet/river/issues/new)                                             | River group chat and `riverctl`        |
+| [web](https://github.com/freenet/web/issues/new)                                                 | This website, freenet.org              |
+| [freenet-git](https://github.com/freenet/freenet-git/issues/new)                                 | Git hosting over Freenet               |
+| [delta](https://github.com/freenet/delta/issues/new)                                             | Decentralized website builder          |
+| [mail](https://github.com/freenet/mail/issues/new)                                               | Decentralized email                    |
+| [atlas](https://github.com/freenet/atlas/issues/new)                                             | Discovery layer, at the RFC stage      |
+| [raven](https://github.com/freenet/raven/issues/new)                                             | Live social feed                       |
+| [freenet-agent-skills](https://github.com/freenet/freenet-agent-skills/issues/new)               | Skills for AI coding agents            |
+| [freenet-stdlib](https://github.com/freenet/freenet-stdlib/issues/new)                           | Contract and delegate library          |
+| [harvest](https://github.com/freenet/harvest/issues/new)                                         | Peer-to-peer marketplace               |
+| [freenet-wiki](https://github.com/freenet/freenet-wiki/issues/new)                               | Decentralized wiki                     |
+| [replay-channel](https://github.com/freenet/replay-channel/issues/new)                           | Rust broadcast-channel library         |
+| [freenet-scaffold](https://github.com/freenet/freenet-scaffold/issues/new)                       | Mergeable contract state crate         |
+| [freenet-telemetry-dashboard](https://github.com/freenet/freenet-telemetry-dashboard/issues/new) | The dashboard at telemetry.freenet.org |
+| [ghostkeys](https://github.com/freenet/ghostkeys/issues/new)                                     | Ghost Keys vault and delegate          |
+| [freenet-migrate](https://github.com/freenet/freenet-migrate/issues/new)                         | App data across version changes        |
+| [freenet-delegates](https://github.com/freenet/freenet-delegates/issues/new)                     | Shared utility delegates               |
+
+Repositories not listed here are internal build and test infrastructure. If a bug seems to belong to
+one of those, file it against [freenet-core](https://github.com/freenet/freenet-core/issues/new) and
+it will get moved.
 
 ## What to put in a bug report
 

--- a/hugo-site/content/community/_index.md
+++ b/hugo-site/content/community/_index.md
@@ -1,5 +1,0 @@
----
-title: "Community"
-date: 2026-08-25
-draft: false
----

--- a/hugo-site/content/quickstart/_index.md
+++ b/hugo-site/content/quickstart/_index.md
@@ -44,7 +44,7 @@ Prefer the terminal? River has a full-featured CLI, `riverctl`. See the
 ## Troubleshooting
 
 If you run into problems, join our [Matrix chat](https://matrix.to/#/#freenet-locutus:matrix.org)
-for help, or see [Report a Bug or Get Help](/community/support/) for where to file a report.
+for help, or see [Report a Bug or Get Help](/bug/) for where to file a report.
 
 **Invite didn't work?** If River opened but you're not in the room, try restarting Freenet
 (`freenet service restart`), then come back to this page and click the invite button again for a
@@ -67,4 +67,4 @@ Need to remove Freenet? See the [uninstall guide](/uninstall/).
 - [User Manual](/build/manual/) - Learn how Freenet works
 - [Video Talks](/about/video-talks/) - Watch presentations about Freenet
 - [FAQ](/about/faq/) - Common questions and answers
-- [Report a Bug or Get Help](/community/support/) - Where to send a bug report or feature idea
+- [Report a Bug or Get Help](/bug/) - Where to send a bug report or feature idea

--- a/hugo-site/static/llms.txt
+++ b/hugo-site/static/llms.txt
@@ -16,7 +16,6 @@ Freenet is a global key-value store where keys are WebAssembly programs called "
 
 - [Homepage](https://freenet.org/): one-page overview with the for-users / for-developers / for-supporters split
 - [FAQ](https://freenet.org/about/faq/): authoritative answers on what Freenet is, project history, the Hyphanet relationship, and how Freenet compares to other decentralized systems
-- [Why Freenet](https://freenet.org/resources/why-freenet/): the motivation — why a decentralized replacement for the web matters
 - [Quickstart](https://freenet.org/quickstart/): install Freenet and try a live app
 - [Uninstall](https://freenet.org/uninstall/): per-platform removal instructions
 

--- a/hugo-site/static/llms.txt
+++ b/hugo-site/static/llms.txt
@@ -41,7 +41,7 @@ Freenet is a global key-value store where keys are WebAssembly programs called "
 - [About](https://freenet.org/about/): project background and leadership
 - [Video talks](https://freenet.org/about/video-talks/): recorded talks explaining Freenet
 - [News](https://freenet.org/about/news/): development updates and announcements
-- [Get involved](https://freenet.org/community/get-involved/): how to contribute
+- [Report a bug](https://freenet.org/bug/): which issue tracker to use for each project, what to put in a report, and how to report a security vulnerability privately
 - [Donate](https://freenet.org/donate/): support the 501(c)(3) non-profit
 - [Ghost Keys](https://freenet.org/ghostkey/): cryptographic anonymous-but-verifiable identities, used for donations and as a building block for decentralized reputation
 

--- a/hugo-site/themes/freenet/layouts/partials/footer.html
+++ b/hugo-site/themes/freenet/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <div class="footer-report">
-    <p><a href="/community/support/">Report a bug or get help</a></p>
+    <p><a href="/bug/">Report a bug or get help</a></p>
 </div>
 <div class="footer-institutional">
     <p>


### PR DESCRIPTION
## Problem

Freenet has no memorable URL for "where do I report a bug". A page does exist,
added in #120, but it lives at `/community/support/`, which nobody guesses and
which reads like a help desk rather than an issue tracker index.

It also stops short of a full list. It triages the four things most people are
using (River, Freenet itself, this website, Ghost Keys) and then names six other
apps in a sentence. The libraries and developer tools have no entry at all, so a
bug in `freenet-stdlib` or `freenet-migrate` has no signposted destination.
There is nothing about security vulnerabilities either, and a public issue for
an unfixed hole is a working attack recipe.

## Approach

One page, not two. Rather than add a second bug page at `/bug/` and leave two
competing versions to drift apart, this moves the existing page there and keeps
`/community/support/` and `/community/get-involved/` as aliases, adding `/bugs/`,
`/report/` and `/community/` alongside them, so every existing link still
resolves. The homepage, quickstart and footer links are repointed to the short
URL.

Three additions to the page itself:

- **A table of every project you can file against**, 19 rows, most-starred
  first. Each name links to that project's issue list, so a reader can check
  whether their bug is already there. It sits below the "what were you using?"
  triage, which stays the primary route: the table is the reference list for the
  cases triage doesn't name.
- **A security callout**, routing vulnerabilities to freenet-core's private
  advisory form with an email fallback for anyone without a GitHub account, and
  saying explicitly that the public Matrix room is not the place for them.
- A cross-reference from the "one of the other apps" section down to the table.

Repos left out of the table are internal build and test infrastructure
(`portal`, `websitemirror`, `freenet-test-network`), dormant (`kweb-up-poc`,
`freenetorg-website`, which is archived), or have issues switched off
(`blindsign`, `freenet-scaffold-macro`). `paper-1` is included: it is public,
accepts issues, and is the source of the whitepaper this site publishes.

One judgment call worth flagging: **the table is two columns, not three.** A
third "New issue" column pushed the table into horizontal scroll on a 390px
viewport, which put the primary action off-screen on a phone. Linking the
project name to the issue list instead keeps the whole table on screen at every
width, and works for a logged-out reader, which `/issues/new` does not.

## Review

Four independent passes: code-first and skeptical Claude reviewers, an external
`codex review`, and a verification pass over the resulting fixes. They found
eleven real problems, including one that mattered: the security callout
originally left a reporter without a GitHub account with only the public Matrix
room, which this page's own text three lines above recommends. All are fixed;
the two consolidated review comments below record each finding and where it
landed. The final external pass reports no regressions.

## Testing

- `hugo` builds clean, no warnings.
- `python3 scripts/check-links.py` passes: no broken internal links, 224 pages.
  Its self-test passes too, so the green is not vacuous.
- All five aliases confirmed redirecting to `/bug/` in the built output, and
  `/community/` no longer publishes an empty section page or an empty feed.
- All 19 linked repos checked via the GitHub API: public, unarchived, issues
  enabled, no issue template that would divert the link, and every URL returns
  200 anonymously.
- The security callout verified in the built HTML: clean prose, no leftover
  script, and a usable address with JavaScript disabled.
- Rendered at 1280px and 390px; no horizontal overflow at either width.

There is a separate theme bug this change worked around rather than fixed: the
breakout rule at `base.css:337` that should let wide tables extend past the
prose column never takes effect, because `max-width: 100%` at `base.css:811`
clamps it. Filed as #168 rather than fixed here, since it changes how tables
render on other pages and deserves its own visual review.

https://claude.ai/code/session_016G7mL6JBHFqXJf7SksY631

[AI-assisted - Claude]
