### PR TITLE
chore(keys): remove the retired AWS gateway from the index

### DIFF
--- a/hugo-site/static/keys/gateways.toml
+++ b/hugo-site/static/keys/gateways.toml
@@ -28,32 +28,3 @@ public_key = "keys/public.gw2.pem"
 
 [gateways.address]
 hostname = "gw2.freenet.org:31338"
-
-# Secondary gateway on independent infrastructure (AWS, different provider,
-# different /24, different uplink). Still running; retirement is pending.
-#
-# Addressed by bare IP deliberately. The name it used to carry was under a
-# personal domain, and this box is being shut down, so a new DNS record for it
-# would be churn for nothing. `hostname` with an IP literal resolves without
-# touching a DNS resolver at all (std's ToSocketAddrs parses it directly).
-#
-# `hostname` rather than `host_address` because it is the shape already in this
-# file and is covered by a back-compat test pinned against the deployed copy,
-# and because an IP literal resolves without touching a resolver at all.
-#
-# NOT for fail-soft reasons. An earlier revision of this comment claimed a bad
-# `hostname` would degrade to one gateway failing at dial time. That is FALSE:
-# `parse_socket_addr(..).await?` runs INSIDE the per-gateway loop
-# (freenet-core node.rs:587), so a single unresolvable entry aborts
-# NodeConfig::new and the node does not start. Any entry here can take every
-# peer down on restart. Treat all three as equally load-bearing.
-#
-# REMOVE THIS ENTRY when the box is actually shut down. Until then it is the
-# only listed gateway outside the host that runs gw1 and gw2, so dropping it
-# early would leave every refetching peer with a bootstrap set confined to a
-# single machine, IP, uplink and datacenter.
-[[gateways]]
-public_key = "keys/public.vega.gw.pem"
-
-[gateways.address]
-hostname = "100.27.151.80:31337"


### PR DESCRIPTION
## Problem

The AWS gateway is being shut down to cut ~$198/mo. It was deliberately kept listed by bare IP through the changeover so no peer lost a bootstrap target while `gw1`/`gw2.freenet.org` adoption happened.

That adoption is now complete: **gw1 has 170 peers and gw2 has 147** — comparable shares of the live network, where gw2 started from zero on 2026-08-29.

## Approach

Drop the AWS entry, leaving the two role-based nova gateways.

The release path stopped touching that host in freenet-core#5540, so nothing in a release run reaches for it any more.

## Rollout

Peers re-fetch this file at startup. One holding a stale copy will dial the AWS address until it refetches — and that gateway stays running until this has propagated, so the dial still succeeds. The two nova entries work throughout. There is no window where a peer has no usable gateway.

Order from here: this merges and deploys → the AWS gateway and gkapi stop → the instance is terminated separately, by hand.

[AI-assisted - Claude]
